### PR TITLE
Fixes for new ngencerf-ui repository name

### DIFF
--- a/components/Common/AboutBox.vue
+++ b/components/Common/AboutBox.vue
@@ -198,7 +198,7 @@ const gitInfoArray = computed(() => {
   let infoArray = Object.entries(gitInfo.value).map(([repository, info]) => ({ repository, ...info }));
   // Append additional git info if it was loaded
   if (infoArray.length && addedGitInfo.value && Object.keys(addedGitInfo.value).length > 0) {
-    addedGitInfo.value.repository = 'ngencerf_ui';
+    addedGitInfo.value.repository = 'ngencerf-ui';
     infoArray.push(addedGitInfo.value);
   }
   getUniqueFields(infoArray);

--- a/runUi.sh
+++ b/runUi.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-# Run ngencerf_ui application
+# Run ngencerf-ui application
 # - Check the current node version against the required version in .nvmrc.
 # - If there's a mismatch, switch node versions using nvm and reinstalls dependencies.
 # - Generates Git information using generate_git_info.sh.
-# - Starts the ngencerf_ui application with npm.
+# - Starts the ngencerf-ui application with npm.
 
-# ngencerf_ui root directory
+# ngencerf-ui root directory
 ngencerf_ui="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the generate_git_info.sh script to use its functions
@@ -68,6 +68,6 @@ fi
 generate_git_info
 echo
 
-echo 'running ngencerf_ui in dev mode...'
+echo 'running ngencerf-ui in dev mode...'
 npm run dev
 echo


### PR DESCRIPTION
Where appropriate, changed ngencerf**_**ui to ngencerf**-**ui. Left the underscore within the bash scripts for variable names.