### PR TITLE
Account for "requested" vs. "actual" forcing sources

### DIFF
--- a/components/Calibration/CalibrationProgressGroup.vue
+++ b/components/Calibration/CalibrationProgressGroup.vue
@@ -26,8 +26,8 @@
         <td data-tab="2" title="Geopackage" aria-label="Geopackage" @click="tabClicked">Geopackage</td>
       </tr>
       <tr>
-        <td><i v-if="userCalibrationRunData?.formulation_name && userCalibrationRunData?.modules.length"
-            :class="userCalibrationRunData?.formulation_name && userCalibrationRunData?.modules.length ? 'checkMark' : ''"
+        <td><i v-if="userCalibrationRunData?.formulation_name && userCalibrationRunData?.modules.length && formulationIsCalibratable"
+            :class="userCalibrationRunData?.formulation_name && userCalibrationRunData?.modules.length && formulationIsCalibratable ? 'checkMark' : ''"
             class="pi pi-check font-bold"></i></td>
         <td data-tab="3" title="Formulation" aria-label="Formulation" @click="tabClicked">Formulation</td>
       </tr>
@@ -77,13 +77,39 @@
 <script lang="ts" setup>
 import { useUserDataStore } from "@/stores/common/UserDataStore";
 import { generalStore } from "@/stores/common/GeneralStore";
+import { useFormulationStore } from "@/stores/calibration/FormulationStore";
 
 const { getCalibrationTabIndex, getMenuIndex } = generalStore();
 const { userCalibrationRunData } = storeToRefs(useUserDataStore());
+const { selectedModuleValues, formulationIsCalibratable } = storeToRefs(useFormulationStore());
+const { validateFormulationTabData } = useFormulationStore();
 
 const currentCalibrationTab = ref(getCalibrationTabIndex());
 
 const emit = defineEmits(["tabNumber"]);
+
+onMounted(async() => {
+  // check to see if formulation is calibratable
+  if (userCalibrationRunData.value?.modules != null) {
+    try {
+      selectedModuleValues.value = JSON.parse(
+        JSON.stringify(userCalibrationRunData.value.modules)
+      );
+    } catch (e) {
+      console.error("Failed to clone modules:", e);
+      selectedModuleValues.value = [];
+    }
+  } else {
+    selectedModuleValues.value = [];
+  }
+  validateFormulationTabData().then(response => {
+    if (response._data.formulation_errors) {
+      formulationIsCalibratable.value = false;
+    } else {
+      formulationIsCalibratable.value = true;
+    }
+  });
+})
 
 const checkStartEndTimeValues = () => {
   return (

--- a/components/Calibration/Formulation.vue
+++ b/components/Calibration/Formulation.vue
@@ -262,6 +262,7 @@ const {
   formulationInfoMessages,
   formulationErrorMessages,
   formulationWarningMessages,
+  formulationIsCalibratable,
   saveFormulationPayload
 } = storeToRefs(useFormulationStore());
 
@@ -426,13 +427,16 @@ const saveFormulationData = () => {
 
     saveFormulationTabData().then(response => {
       if (response.status === 200) {
+        formulationIsCalibratable.value = true;
         if (response._data.eds_errors) {
+          formulationIsCalibratable.value = false;
           response._data.eds_errors.forEach((err: any) => {
             const tMsg: ToastMessageOptions = { severity: 'error', summary: 'External Formulation Error', detail: err.message, life: ToastTimeout.timeoutError };
             toast.add(tMsg); addToastRecord(tMsg);
           });
         }
         if (response._data.formulation_errors) {
+          formulationIsCalibratable.value = false;
           response._data.formulation_errors.forEach((err: any) => {
             const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Formulation Error', detail: err, life: ToastTimeout.timeoutError };
             toast.add(tMsg); addToastRecord(tMsg);

--- a/components/Calibration/HeadwaterBasinGage.vue
+++ b/components/Calibration/HeadwaterBasinGage.vue
@@ -560,7 +560,18 @@ const updateJobData = async (response: any) => {
     userCalibrationRunData.value.geopackage_source = gagePayload.value.geopackage_source as string;
     userCalibrationRunData.value.geopackage_image_url = response?._data?.geopackage_image_url ?? "";
 
-    // check for EDS errors
+    // Assume EDS status is true if sources are set
+    if (userCalibrationRunData.value.forcing_source_actual !== '') {
+      userCalibrationRunData.value.external_data_status.forcing = true;
+    }
+    if (userCalibrationRunData.value.observational_source !== '') {
+      userCalibrationRunData.value.external_data_status.observational = true;
+    }
+    if (userCalibrationRunData.value.geopackage_source !== '') {
+      userCalibrationRunData.value.external_data_status.geopackage = true;
+    }
+
+    // Now check for EDS errors
     if(response?._data?.eds_errors) {
       response._data.eds_errors.forEach((eds_error: edsError) => {
         if (eds_error.name === 'forcing') {

--- a/components/Calibration/HeadwaterBasinGage.vue
+++ b/components/Calibration/HeadwaterBasinGage.vue
@@ -560,11 +560,26 @@ const updateJobData = async (response: any) => {
     userCalibrationRunData.value.geopackage_source = gagePayload.value.geopackage_source as string;
     userCalibrationRunData.value.geopackage_image_url = response?._data?.geopackage_image_url ?? "";
 
-    userCalibrationRunData.value.num_catchments = response?._data.num_catchments;
+    // check for EDS errors
+    if(response?._data?.eds_errors) {
+      response._data.eds_errors.forEach((eds_error: edsError) => {
+        if (eds_error.name === 'forcing') {
+          userCalibrationRunData.value.forcing_source_actual = '';
+          userCalibrationRunData.value.external_data_status.forcing = false;
+        }
+        else if (eds_error.name === 'observational') {
+          userCalibrationRunData.value.observational_source = '';
+          userCalibrationRunData.value.external_data_status.observational = false;
+        }
+        else if (eds_error.name === 'geopackage') {
+          userCalibrationRunData.value.geopackage_source = '';
+          userCalibrationRunData.value.geopackage_image_url = '';
+          userCalibrationRunData.value.external_data_status.geopackage = false;
+        }
+      })
+    }
 
-    userCalibrationRunData.value.external_data_status.forcing = !(userCalibrationRunData.value.forcing_source_requested === "");
-    userCalibrationRunData.value.external_data_status.observational = !(userCalibrationRunData.value.observational_source === "");
-    userCalibrationRunData.value.external_data_status.geopackage = !(userCalibrationRunData.value.geopackage_source === "");
+    userCalibrationRunData.value.num_catchments = response?._data.num_catchments;
   }
 }
 

--- a/components/Calibration/HeadwaterBasinGage.vue
+++ b/components/Calibration/HeadwaterBasinGage.vue
@@ -29,11 +29,11 @@
         <div class="row-span-1">
           <div class="grid grid-cols-3 gap-4">
             <div class="col-span-1">
-              <label for="Forcing">Forcing Data</label><br />
+              <label for="Forcing">Forcing Source</label><br />
               <Select id="Forcing" v-model="selectedForcingValue" :options="getForcingOptionsList" optionLabel="name"
                 optionValue="name" class="user-select" defaultValue="AORC" @change="uploadForcingDlgOpen($event)"
                 :disabled="!isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.status)"
-                aria-label="Forcing Data Select" title="Forcing Data Select"></Select>
+                aria-label="Forcing Source Select" title="Forcing Source Select"></Select>
             </div>
 
             <div class="col-span-1">
@@ -554,8 +554,8 @@ const updateJobData = async (response: any) => {
     }
 
     userCalibrationRunData.value.gage = newGage;
-    userCalibrationRunData.value.forcing_source_requested = response?._data?.forcing_source_actual as string;
-    userCalibrationRunData.value.forcing_source_actual = response?._data?.forcing_source_requested as string;
+    userCalibrationRunData.value.forcing_source_requested = response?._data?.forcing_source_requested as string;
+    userCalibrationRunData.value.forcing_source_actual = response?._data?.forcing_source_actual as string;
     userCalibrationRunData.value.observational_source = gagePayload.value.observational_source as string;
     userCalibrationRunData.value.geopackage_source = gagePayload.value.geopackage_source as string;
     userCalibrationRunData.value.geopackage_image_url = response?._data?.geopackage_image_url ?? "";

--- a/components/Calibration/HeadwaterBasinGage.vue
+++ b/components/Calibration/HeadwaterBasinGage.vue
@@ -585,15 +585,15 @@ const validateTab = () => {
     error = true;
     text.push("Gage value has been changed");
   }
-  if (selectedObservationalValue.value !== userCalibrationRunData?.value?.observational_source) {
-    error = true;
-    text.push("Observational Source has been changed");
-  }
-  if (selectedForcingValue.value != userCalibrationRunData?.value?.forcing_source) {
+  if (selectedForcingValue.value != resetData.value.forcing_source_requested) {
     error = true;
     text.push("Forcing Source has been changed");
   }
-  if (selectedGeopackageValue.value != userCalibrationRunData?.value?.geopackage_source) {
+  if (selectedObservationalValue.value !== resetData.value.observational_source) {
+    error = true;
+    text.push("Observational Source has been changed");
+  }
+  if (selectedGeopackageValue.value != resetData.value.geopackage_source) {
     error = true;
     text.push("GeoPackage has been changed");
   }

--- a/components/Calibration/HeadwaterBasinGage.vue
+++ b/components/Calibration/HeadwaterBasinGage.vue
@@ -206,7 +206,7 @@ const resetData = ref<GageResetData>({
   },
   geopackage_source: "",
   observational_source: "",
-  forcing_source: "",
+  forcing_source_requested: "",
   geopackage_image_url: ""
 })
 
@@ -214,7 +214,7 @@ const setResetDataValues = () => {
   if (userCalibrationRunData.value) {
     // Save all information from the external data JSON.parse(JSON.stringify(obj));
     resetData.value.external_data_status = JSON.parse(JSON.stringify(userCalibrationRunData.value.external_data_status));
-    resetData.value.forcing_source = userCalibrationRunData.value.forcing_source ? userCalibrationRunData.value.forcing_source : (getForcingOptionsList.value ? getForcingOptionsList.value[0].name : '');
+    resetData.value.forcing_source_requested = userCalibrationRunData.value.forcing_source_requested ? userCalibrationRunData.value.forcing_source_requested : (getForcingOptionsList.value ? getForcingOptionsList.value[0].name : '');
     resetData.value.observational_source = userCalibrationRunData.value.observational_source ? userCalibrationRunData.value.observational_source : (getObservationalOptionsList.value ? getObservationalOptionsList.value[0].name : '');
     resetData.value.geopackage_source = userCalibrationRunData.value.geopackage_source ? userCalibrationRunData.value.geopackage_source : (getGeopackageOptionsList.value ? getGeopackageOptionsList.value[0].name : '');
     resetData.value.geopackage_image_url = userCalibrationRunData.value.geopackage_image_url;
@@ -231,7 +231,7 @@ onMounted(() => {
     if (gageHasChanged.value && userCalibrationRunData?.value?.gage?.gage_id) {
       gageSelectionReset();
     } else {
-      selectedForcingValue.value = resetData.value.forcing_source;
+      selectedForcingValue.value = resetData.value.forcing_source_requested;
       selectedObservationalValue.value = resetData.value.observational_source;
       selectedGeopackageValue.value = resetData.value.geopackage_source;
     }
@@ -294,12 +294,12 @@ const gageSelectionReset = () => {
     userCalibrationRunData.value.external_data_status = JSON.parse(JSON.stringify(resetData.value.external_data_status))
     userCalibrationRunData.value.geopackage_source = resetData.value.geopackage_source;
     userCalibrationRunData.value.observational_source = resetData.value.observational_source;
-    userCalibrationRunData.value.forcing_source = resetData.value.forcing_source;
+    userCalibrationRunData.value.forcing_source_requested = resetData.value.forcing_source_requested;
     userCalibrationRunData.value.geopackage_image_url = resetData.value.geopackage_image_url;
   }
   selectedGeopackageValue.value = resetData.value.geopackage_source;
   selectedObservationalValue.value = resetData.value.observational_source;
-  selectedForcingValue.value = resetData.value.forcing_source;
+  selectedForcingValue.value = resetData.value.forcing_source_requested;
 }
 
 const clearDataDueToGageChange = () => {
@@ -385,7 +385,7 @@ const showForcingFileUploadDialog = (headerText: string) => {
         saveFunction: saveUserForcingFiles
       },
       onClose: (opt) => {
-        if (selectedForcingValue.value !== userCalibrationRunData?.value?.forcing_source) {
+        if (selectedForcingValue.value !== userCalibrationRunData?.value?.forcing_source_requested) {
           gageDataSourceHasChanged.value = true;
         }
         handleDialogClose(opt)
@@ -554,14 +554,15 @@ const updateJobData = async (response: any) => {
     }
 
     userCalibrationRunData.value.gage = newGage;
-    userCalibrationRunData.value.forcing_source = gagePayload.value.forcing_source as string;
+    userCalibrationRunData.value.forcing_source_requested = response?._data?.forcing_source_actual as string;
+    userCalibrationRunData.value.forcing_source_actual = response?._data?.forcing_source_requested as string;
     userCalibrationRunData.value.observational_source = gagePayload.value.observational_source as string;
     userCalibrationRunData.value.geopackage_source = gagePayload.value.geopackage_source as string;
     userCalibrationRunData.value.geopackage_image_url = response?._data?.geopackage_image_url ?? "";
 
     userCalibrationRunData.value.num_catchments = response?._data.num_catchments;
 
-    userCalibrationRunData.value.external_data_status.forcing = !(userCalibrationRunData.value.forcing_source === "");
+    userCalibrationRunData.value.external_data_status.forcing = !(userCalibrationRunData.value.forcing_source_requested === "");
     userCalibrationRunData.value.external_data_status.observational = !(userCalibrationRunData.value.observational_source === "");
     userCalibrationRunData.value.external_data_status.geopackage = !(userCalibrationRunData.value.geopackage_source === "");
   }

--- a/components/Common/MessagesGroup.vue
+++ b/components/Common/MessagesGroup.vue
@@ -14,23 +14,29 @@
           <div v-if="calData?.num_catchments" :aria-label="'Catchments ' + calData?.num_catchments"
             :title="'Gage ' + calData?.num_catchments"><span class="font-medium">Catchments:</span>
             {{ calData?.num_catchments }}</div>
-
-          <div v-if="calData?.forcing_source" :aria-label="'Forcing Data ' + calData?.forcing_source"
-            :title="'Forcing Data ' + calData?.forcing_source"><span class="font-medium">Forcing Data:</span>
-            {{ calData?.forcing_source }}
-          </div>
-          <div v-if="calData?.observational_source" :aria-label="'Observational Data ' + calData?.observational_source"
-            :title="'Observational Data ' + calData?.observational_source"><span class="font-medium">Observational
-              Data:</span> {{
-                calData?.observational_source }}
-          </div>
-
         </div>
 
         <div class="col-span-1">
           <div v-if="calData?.gage?.station_name" :aria-label="'Station Name ' + calData?.gage?.station_name"
             :title="'Station Name ' + calData?.gage?.station_name">
             <span class="font-medium">{{ calData?.gage?.station_name }}</span>
+          </div>
+        </div>
+
+        <div class="col-span-2">
+          <div v-if="calData?.forcing_source_requested" :aria-label="'Forcing Data ' + calData?.forcing_source_requested"
+            :title="'Forcing Data ' + calData?.forcing_source_requested"><span class="font-medium">Forcing Source: </span>
+            <span v-if="(calData?.forcing_source_actual && calData.forcing_source_actual != calData?.forcing_source_requested)">
+              {{ calData?.forcing_source_requested }} (Requested), {{ calData?.forcing_source_actual }} (Actual)
+            </span>
+            <span v-else>
+              {{ calData?.forcing_source_requested }}
+            </span>
+          </div>
+          <div v-if="calData?.observational_source" :aria-label="'Observational Data ' + calData?.observational_source"
+            :title="'Observational Data ' + calData?.observational_source"><span class="font-medium">Observational
+              Data:</span> 
+            {{ calData?.observational_source }}
           </div>
         </div>
       </div>

--- a/composables/NgencerfModels.ts
+++ b/composables/NgencerfModels.ts
@@ -45,6 +45,7 @@ export interface NonFieldError {
 export interface GageBasinApiSavedResponse extends GeneralApiSaveResponse {
   geopackage_image_url?: string | null;
   eds_errors: edsError[];
+  warnings: string[];
 }
 
 export interface CreateRunValidationApiResponse extends GeneralApiSaveResponse {
@@ -141,7 +142,8 @@ export interface UserCalibrationRunData {
   job_data_dir: string;
   submit_date: string; // e.g. "2024-09-13T05:50:22.334Z"
   gage: GageData;
-  forcing_source: string;
+  forcing_source_requested: string;
+  forcing_source_actual: string;
   forcing_user_dir: string;
   forcing_dir_path: string;
   observational_source: string;
@@ -266,7 +268,7 @@ export interface GageOptionData {
 export interface SaveGageTabPayload {
   calibration_run_id?: number;
   gage_id?: string;
-  forcing_source?: string;
+  forcing_source_requested?: string;
   observational_source?: string;
   geopackage_source?: string;
 }
@@ -742,7 +744,7 @@ export type GageResetData = {
   };
   geopackage_source: string;
   observational_source: string;
-  forcing_source: string;
+  forcing_source_requested: string;
   geopackage_image_url: string;
 }
 

--- a/composables/ValidationHandlers.ts
+++ b/composables/ValidationHandlers.ts
@@ -54,6 +54,17 @@ export const useProcessCalibrationGageSavedResponse = (savedResponse: GageBasinA
     })
   }
 
+  if (savedResponse.hasOwnProperty('warnings') && savedResponse.warnings.length > 0) {
+    savedResponse.warnings.forEach((warning: string) => {
+      messages.value.push({
+        severity: 'warn',
+        summary: 'AORC Error',
+        detail: warning,
+        life: ToastTimeout.timeoutWarn
+      });
+    })
+  }
+
   return messages.value;
 }
 

--- a/pages/LandingPage.vue
+++ b/pages/LandingPage.vue
@@ -69,10 +69,10 @@ onMounted(async () => {
   hardResetTuningStore();
   await loadFormulationModels();
   await fetchUserCalibrationJobsListData();
-  if (!formulationTabData.value) {
+  /* if (!formulationTabData.value) {
     const tMsg: ToastMessageOptions = { severity: "error", summary: 'Server Error', detail: "Unable to Retrieve Module List", life: ToastTimeout.timeoutError };
     toast.add(tMsg); addToastRecord(tMsg);
-  }
+  } */
 })
 
 </script>

--- a/stores/calibration/FormulationStore.ts
+++ b/stores/calibration/FormulationStore.ts
@@ -37,6 +37,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
   const formulationInfoMessages = ref<string[]>([]);
   const formulationErrorMessages = ref<string[]>([]);
   const formulationWarningMessages = ref<string[]>([]);
+  const formulationIsCalibratable = ref<boolean>(false);
 
   const saveFormulationPayload = ref<SaveFormulationTabPayload>({});
 
@@ -295,9 +296,12 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
       formulationErrorMessages.value = [];
       formulationWarningMessages.value = [];
       if (response._data.formulation_errors) {
+        formulationIsCalibratable.value = false;
         response._data.formulation_errors.forEach((err: any) => {
           formulationErrorMessages.value.push('Error: ' + err);
         });
+      } else {
+        formulationIsCalibratable.value = true;
       }
       if (response._data.formulation_warnings) {
         response._data.formulation_warnings.forEach((err: any) => {
@@ -333,6 +337,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
         saveFormulationPayload.value
       );
       if (Object.keys(saveValidation.value).length > 0) {
+        formulationIsCalibratable.value = false;
         return Promise.resolve({
           _data: {
             message: "Unable to save formulation tab.",
@@ -401,6 +406,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
     formulationInfoMessages,
     formulationErrorMessages,
     formulationWarningMessages,
+    formulationIsCalibratable,
     filterGroup,
     useSlothParameters,
     selectedModuleValues,

--- a/stores/calibration/GageStore.ts
+++ b/stores/calibration/GageStore.ts
@@ -175,7 +175,7 @@ export const useGageStore = defineStore(
       if (selectedGageValue.value)
         gagePayload.value["gage_id"] = selectedGageValue.value;
       if (selectedForcingValue.value)
-        gagePayload.value["forcing_source"] = selectedForcingValue.value;
+        gagePayload.value["forcing_source_requested"] = selectedForcingValue.value;
       if (selectedObservationalValue.value)
         gagePayload.value["observational_source"] = selectedObservationalValue.value;
       if (selectedGeopackageValue.value)


### PR DESCRIPTION
Make sure the UI can manage the situation where AORC data is requested but not available, and the server tells it to default to NWM Retrospective as the Forcing Source. Display this properly in the right column, and make sure the proper checkmarks for Forcing, Observational, and Geopackage are shown/hidden based on the response from the server and any EDS errors indicated.