### PR TITLE
Reset to defaults when switching Optimization Algorithm

### DIFF
--- a/components/Calibration/OptimizationMetrics.vue
+++ b/components/Calibration/OptimizationMetrics.vue
@@ -441,7 +441,7 @@ const validateTab = () => {
       error = true;
       text.push("Plot Generation Frequency has been changed");
     }
-    if (userCalibrationRunData?.value?.optimization_inputs.length !== uiOptimizationInputs.value.length) {
+    if (userCalibrationRunData?.value?.optimization_inputs?.length !== uiOptimizationInputs?.value?.length) {
       error = true;
       text.push("Algorithm Parameters have been changed");
     }

--- a/stores/calibration/OptimizationStore.ts
+++ b/stores/calibration/OptimizationStore.ts
@@ -139,11 +139,13 @@ export const useOptimizationStore = defineStore(
             name: data_input.name,
             value: data_input.default_value,
           };
-          let user_optimization_input = filterCalRunData(data_input.name);
+	  // Commenting out because we don't want to replace defaults with previous user selections
+	  // when switching optimization algorithm
+          /* let user_optimization_input = filterCalRunData(data_input.name);
 
           if (user_optimization_input && user_optimization_input.length !== 0) {
             data_item.value = user_optimization_input[0].value;
-          }
+          } */
 
           data_items.push(data_item);
         });


### PR DESCRIPTION
Only load user-entered Algorithm parameters when the Optimization Metrics tab is first mounted, or when the user reverts to previously saved values. When switching the Optimization Algorithm, reset parameters to their defaults for that algorithm.