### PR TITLE
Track/clear intervals consistently in Run/Status tab

### DIFF
--- a/components/Evaluation/EvaluationRunStatus.vue
+++ b/components/Evaluation/EvaluationRunStatus.vue
@@ -227,8 +227,8 @@ const startRun = async () => {
       iterationValidationRunId.value = displayValidationId.value = response?._data.validation_run_id;
       startTime.value = response?._data?.submit_date;
       validationRunningTimeInterval.value = setInterval(async () => {
-        updateRunningTime(), 1000
-      }, 10000) as unknown as number;
+        updateRunningTime()
+      }, 1000) as unknown as number;
     } else {
       const tMsg: ToastMessageOptions = { severity: 'warn', summary: 'Unable to Create Validation', life: ToastTimeout.timeoutWarn };
       toast.add(tMsg); addToastRecord(tMsg);
@@ -283,13 +283,6 @@ const updateLogDisplay = () => {
 }
 
 watch(validationStatus, async (newStatus, initialStatus) => {
-  const tMsg: ToastMessageOptions = { 
-    severity: 'info', 
-    summary: 'EvaluationRunStatus.vue Line 314', 
-    detail: 'Validation status has changed to: ' + validationStatus.value, 
-    life: ToastTimeout.timeoutInfo 
-  };
-  toast.add(tMsg); addToastRecord(tMsg);
   if (newStatus !== null && !isValidationRunStopped(newStatus)) {
     validationStatusCheckingInterval.value = setInterval(async () => {
       queryIterationValidationRunStatus().then(response => {

--- a/components/Evaluation/SelectAltIterationTab.vue
+++ b/components/Evaluation/SelectAltIterationTab.vue
@@ -102,7 +102,7 @@ const {
 } = storeToRefs(useEvaluationAltIterationStore());
 
 const { clearRunningStatusInfo } = useEvaluationRunStatusStore();
-const { iterationValidationRunId } = storeToRefs(useEvaluationRunStatusStore());
+const { iterationValidationRunId, validationRunningTimeInterval, validationStatusCheckingInterval } = storeToRefs(useEvaluationRunStatusStore());
 const { calibrationJobId, evaluateIterationRunId, evaluateValidationRunId, evaluateDisplayIterationNumber } = storeToRefs(generalStore());
 
 const selectedCalibrationByIterationDetailRow = ref<any>();
@@ -119,6 +119,11 @@ onMounted(() => {
   nextTick(() => {
     resetEvaluationAltIterationStore();
     fetchCalibrationDataByIterationDataList();
+    
+    //clear intervals if user was on Run/Status tab
+    console.log('Line 125: SelectAltIterationTab has been mounted. Clearing all intervals.');
+    clearInterval(validationStatusCheckingInterval.value);
+    clearInterval(validationRunningTimeInterval.value);
 
     const syncScroll = (source: any, target: any) => {
       source.addEventListener("scroll", (event: Event) => {


### PR DESCRIPTION
Get status every 10 seconds only while job is running

Update Elapsed Time every second, only while job is running

Clear intervals when Run/Status tab is unmounted or when job stops running

Re-establish intervals when user returns to a running job