### PR TITLE
Enable AET Rootzone on UI side

### DIFF
--- a/components/Calibration/Formulation.vue
+++ b/components/Calibration/Formulation.vue
@@ -38,6 +38,12 @@
 
               </template>
             </Listbox>
+            <div v-if="selectedModuleValues.some(item => item.toLowerCase() === 'cfe-s') || selectedModuleValues.some(item => item.toLowerCase() === 'cfe-x')">
+              <span class="text-left pt-1">
+                <input type="checkbox" id="isAETRootzone" class="ml-2" v-model="isAETRootzone" @change="isAETRootzoneHasChanged = true"/>
+                <label class="inline-block text-[18px]" for="isAETRootzone">&nbsp;CFE AET Rootzone</label>
+              </span>
+            </div>
           </div>
           <div class="col-span-2">&nbsp;</div>
           <div class="col-span-5">
@@ -169,9 +175,9 @@
           </div>
         </span>
 
-        <span v-if="formulationNameHasChanged || modulesHaveChanged">
+        <span v-if="formulationNameHasChanged || modulesHaveChanged || isAETRootzoneHasChanged">
           <div class="col-span-1 mr-3">
-            <Button class="ngenButtonDiv-yellow" title="Revert Changes" @click="restorePage()"
+            <Button class="ngenButtonDiv-yellow" title="Revert Changes" @click="restoreTab()"
               aria-label="Revert Changes">Revert</Button>
           </div>
         </span>
@@ -252,6 +258,7 @@ const {
   useSlothParameters,
   selectedModuleValues,
   formulationNameInput,
+  isAETRootzone,
   slothParameterInputs,
   fetchFormulationModuleOptions,
   fetchFormulationModuleCoveredGroupFilterOptions,
@@ -291,6 +298,7 @@ let dataTableElement: HTMLElement | null = null;
 
 const toast = useToast();
 const formulationNameHasChanged = ref<boolean>(false);
+const isAETRootzoneHasChanged = ref<boolean>(false);
 
 onMounted(async() => {
   if (calibrationJobId.value) {
@@ -375,6 +383,9 @@ const resetModuleList = () => {
       modulesHaveChanged.value = false;
     }
   }
+  if (userCalibrationRunData?.value?.is_aet_rootzone) {
+    isAETRootzone.value = userCalibrationRunData.value.is_aet_rootzone;
+  }
 }
 
 /**
@@ -400,6 +411,10 @@ watch(formulationNameInput, () => {
 * event bus for calibration button group click
 */
 const saveFormulationData = () => {
+  // de-select AET Rootzone if formulation does not include CFE
+  if (!selectedModuleValues.value.some(item => item.toLowerCase() === 'cfe-s') && !selectedModuleValues.value.some(item => item.toLowerCase() === 'cfe-x')) {
+    isAETRootzone.value = false;
+  }
   if (!isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.value?.status)) {
     const tMsg: ToastMessageOptions = { severity: 'warn', summary: 'Unable to Save', detail: 'Update of a job already run is not allowed. Please clone to make any changes for a new calibration', life: ToastTimeout.timeoutWarn };
     toast.add(tMsg); addToastRecord(tMsg);
@@ -453,6 +468,7 @@ const saveFormulationData = () => {
         isLoading.value = false;
         formulationNameHasChanged.value = false;
         modulesHaveChanged.value = false;
+        isAETRootzoneHasChanged.value = false;
         updateJobData();
       } else {
         isLoading.value = false;
@@ -538,6 +554,11 @@ const validateTab = () => {
     selectedModuleValues.value = ['LSTM', 'T-Route'];
     text.push("LSTM can only be paired with T-Route");
   }
+  /* Has user checked/unchecked AET Rootzone? */
+  if (isAETRootzoneHasChanged.value) {
+    error = true;
+    text.push("CFE AET Rootzone has changed");
+  }
   /* Has user checked/unchecked Add SLoTH output variables? */
   if (useSlothParameters.value !== userCalibrationRunData?.value?.use_sloth) {
     error = true;
@@ -551,13 +572,15 @@ const validateTab = () => {
   return { error: error, text: text }
 }
 
-const restorePage = () => {
+const restoreTab = () => {
   formulationNameInput.value = userCalibrationRunData?.value?.formulation_name ? userCalibrationRunData?.value?.formulation_name : "";
   resetModuleList();
   updateFormulationValidRefs();
   if (userCalibrationRunData.value) {
+    isAETRootzone.value = userCalibrationRunData?.value?.is_aet_rootzone;
     useSlothParameters.value = userCalibrationRunData?.value?.use_sloth;
     slothParameterInputs.value = userCalibrationRunData?.value?.sloth_parameters;
+    isAETRootzoneHasChanged.value = false;
   }
 }
 
@@ -629,7 +652,7 @@ const handleNextPrevDialogClose = (opt: any) => {
 }
 
 onUnmounted(async() => {
-  restorePage();
+  restoreTab();
 })
 </script>
 

--- a/components/Calibration/Formulation.vue
+++ b/components/Calibration/Formulation.vue
@@ -497,6 +497,7 @@ const updateJobData = () => {
   if (userCalibrationRunData.value) {
     userCalibrationRunData.value.formulation_name = saveFormulationPayload.value.formulation_name ?? '';
     userCalibrationRunData.value.modules = saveFormulationPayload.value.modules as string[];
+    userCalibrationRunData.value.is_aet_rootzone = saveFormulationPayload.value.is_aet_rootzone;
     userCalibrationRunData.value.sloth_parameters = saveFormulationPayload.value.sloth_parameters as [];
     userCalibrationRunData.value.use_sloth = saveFormulationPayload.value.use_sloth as boolean;
     clearCalibratableParameters();

--- a/components/Calibration/Formulation.vue
+++ b/components/Calibration/Formulation.vue
@@ -38,11 +38,12 @@
 
               </template>
             </Listbox>
-            <div v-if="selectedModuleValues.some(item => item.toLowerCase() === 'cfe-s') || selectedModuleValues.some(item => item.toLowerCase() === 'cfe-x')">
-              <span class="text-left pt-1">
-                <input type="checkbox" id="isAETRootzone" class="ml-2" v-model="isAETRootzone" @change="isAETRootzoneHasChanged = true"/>
-                <label class="inline-block text-[18px]" for="isAETRootzone">&nbsp;CFE AET Rootzone</label>
-              </span>
+            <div class="pt-4 pl-2" v-if="selectedModuleValues.some(item => item.toLowerCase() === 'cfe-s') || selectedModuleValues.some(item => item.toLowerCase() === 'cfe-x')">
+              <Checkbox id="isAETRootzone" inputId="isAETRootzone" class="h-5 w-5 mr-3" style="display:inline-block"
+                :binary="true" v-model="isAETRootzone" aria-label="CFE AET Rootzone Checkbox"
+                title="CFE AET Rootzone Checkbox" @change="isAETRootzoneHasChanged = true" 
+                :disabled="!isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.status)"/>
+              <label for="isAETRootzone" class="inline">CFE AET Rootzone</label>
             </div>
           </div>
           <div class="col-span-2">&nbsp;</div>

--- a/components/Common/MessagesGroup.vue
+++ b/components/Common/MessagesGroup.vue
@@ -27,7 +27,7 @@
           <div v-if="calData?.forcing_source_requested" :aria-label="'Forcing Data ' + calData?.forcing_source_requested"
             :title="'Forcing Data ' + calData?.forcing_source_requested"><span class="font-medium">Forcing Source: </span>
             <span v-if="(calData?.forcing_source_actual && calData.forcing_source_actual != calData?.forcing_source_requested)">
-              {{ calData?.forcing_source_actual }}, {{ calData?.forcing_source_requested }} (Requested)
+              {{ calData?.forcing_source_actual }} ({{ calData?.forcing_source_requested }} Was Requested)
             </span>
             <span v-else>
               {{ calData?.forcing_source_requested }}
@@ -51,6 +51,10 @@
           <div v-if="calData?.modules?.length" :aria-label="'Modules ' + getModuleList()"
             :title="'Modules ' + getModuleList()"><span class="font-medium">Modules:
             </span>{{ getModuleList() }}</div>
+          <div v-if="calData?.modules?.includes('CFE-S') || calData?.modules?.includes('CFE-X')" :aria-label="'CFE AET Rootzone ' + (calData?.is_aet_rootzone ? 'Yes' : 'No')"
+            :title="'CFE AET Rootzone ' + (calData?.is_aet_rootzone ? 'Yes' : 'No')">
+            <span class="font-medium">CFE AET Rootzone:
+            </span>{{ (calData?.is_aet_rootzone ? 'Yes' : 'No') }}</div>
         </div>
       </div>
 

--- a/composables/NgencerfEnums.ts
+++ b/composables/NgencerfEnums.ts
@@ -143,6 +143,7 @@ export const JobStatusAction = {
 
 export const ValidationFormFields = {
   formulation_name: "Formulation Name",
+  is_aet_rootzone: "CFE AET Rootzone",
   modules: "Formulation Modules",
   sloth_parameters: "Sloth Parameters",
   maps_to_module: "Sloth Parameter For Module",

--- a/composables/NgencerfModels.ts
+++ b/composables/NgencerfModels.ts
@@ -161,6 +161,7 @@ export interface UserCalibrationRunData {
   }
   modules: string[];
   formulation_name: string;
+  is_aet_rootzone: boolean;
   formulation_warning?: FormulationWarning;
   use_sloth: boolean;
   sloth_parameters: SlothParameterData[];
@@ -330,6 +331,7 @@ export interface FormulationModuleData {
 export interface SaveFormulationTabPayload {
   calibration_run_id?: number;
   formulation_name?: string;
+  is_aet_rootzone?: boolean;
   modules?: string[];
   use_sloth?: boolean;
   sloth_parameters?: SlothParameterData[];

--- a/stores/calibration/FormulationStore.ts
+++ b/stores/calibration/FormulationStore.ts
@@ -30,6 +30,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
   const filterGroup = ref<string>("");
   const selectedModuleValues = ref<string[]>([]);
   const formulationNameInput = ref<string>("");
+  const isAETRootzone = ref<boolean>(false);
   const slothParameterInputs = ref<SlothParameterData[]>([]);
   const useSlothParameters = ref<boolean>(false);
 
@@ -79,6 +80,9 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
         }
     } else {
         selectedModuleValues.value = [];
+    }
+    if (userCalibrationRunData.value?.is_aet_rootzone) {
+      isAETRootzone.value = true;
     }
     useSlothParameters.value = userCalibrationRunData.value?.use_sloth ?? false;
     slothParameterInputs.value =
@@ -329,6 +333,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
       : "";
     saveFormulationPayload.value.modules =
       selectedModuleValues.value.length > 0 ? selectedModuleValues.value : [];
+    saveFormulationPayload.value.is_aet_rootzone = isAETRootzone.value;
     saveFormulationPayload.value.sloth_parameters =
       slothParameterInputs.value.length > 0 ? slothParameterInputs.value : [];
 
@@ -397,6 +402,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
   const resetFormulationStore = (): void => {
     formulationNameInput.value = "";
     selectedModuleValues.value = ['T-Route'];
+    isAETRootzone.value = false;
     useSlothParameters.value = false;
     slothParameterInputs.value = [];
   };
@@ -411,6 +417,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
     useSlothParameters,
     selectedModuleValues,
     formulationNameInput,
+    isAETRootzone,
     slothParameterInputs,
     fetchFormulationModuleOptions,
     fetchFormulationModuleCoveredGroupFilterOptions,


### PR DESCRIPTION
Allow a value to be set in the database for "is_aet_rootzone" on any job with CFE in the formulation. Default this value to false (and don't accept a value of True) for all other formulations.