### PR TITLE
Update running time immediately when job is submitted

### DIFF
--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -446,7 +446,7 @@ onMounted(async () => {
 const createElapsedTimeInterval = () => {
   elapsedTimeIntervalId.value = setInterval(async () => {
     if (
-      userCalibrationRunData.value?.status === 'Running' || 
+      ['Validating and Preparing Job Data','Running'].includes(userCalibrationRunData.value?.status) || 
       (userCalibrationRunData.value?.status === 'Done' &&
       (!validControlAndValidBestStatus.value || ['Submitted', 'Ready', 'Running'].includes(validControlAndValidBestStatus.value ?? '')))) {
       // Calculate calibrationElapsedTime every second while Calibration is Running or Validation is not Done
@@ -460,10 +460,14 @@ const createElapsedTimeInterval = () => {
 
 // Run Calibration Job
 const startRun = async () => {
-  isLoading.value = true;
+  //isLoading.value = true;
   validationBestAchieved.value.isBest = false;
   if (userCalibrationRunData.value) {
     userCalibrationRunData.value.status = 'Validating and Preparing Job Data';
+
+    submitTimeDate.value = new Date();
+
+    createElapsedTimeInterval();
 
     const runCalibrationResponse = await runCalibrationJob();
 
@@ -510,12 +514,12 @@ const startRun = async () => {
     const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Error', detail: 'userCalibrationRunData not set', life: ToastTimeout.timeoutError };
     toast.add(tMsg); addToastRecord(tMsg);
   }
-  isLoading.value = false;
+  //isLoading.value = false;
 };
 
 // Cancel Calibration Job
 const cancelRun = async () => {
-  if (calibrationStatus.value === 'Running') {
+  if (calibrationStatus.value === 'Running'  || validationControlStatus.value === 'Running' || validationBestStatus.value === 'Running') {
     try {
       const cancelCalibrationResponse = await cancelCalibrationJob();
 
@@ -537,7 +541,7 @@ const cancelRun = async () => {
       toast.add(tMsg); addToastRecord(tMsg);
     }
   } else {
-    const tMsg: ToastMessageOptions = { severity: 'warn', summary: 'Warning', detail: 'Calibration status not set to Running. Cannot cancel Calibration', life: ToastTimeout.timeoutWarn };
+    const tMsg: ToastMessageOptions = { severity: 'warn', summary: 'Warning', detail: 'Calibration/Validation status not set to Running. Cannot cancel Calibration', life: ToastTimeout.timeoutWarn };
     toast.add(tMsg); addToastRecord(tMsg);
   }
 };
@@ -607,7 +611,7 @@ watch(overallCalibrationValidationStatus, async (newCalibrationStatus, oldCalibr
 
         // calculate running time every second while calibration is Running 
         // or calibration is Done and valid_control and valid_best have not started or are Submitted, Ready, Running
-        if (userCalibrationRunData.value?.status === 'Running' || (userCalibrationRunData.value?.status === 'Done' &&
+        if (['Validating and Preparing Job Data','Running'].includes(userCalibrationRunData.value?.status) || (userCalibrationRunData.value?.status === 'Done' &&
           (!validControlAndValidBestStatus.value || ['Submitted', 'Ready', 'Running'].includes(validControlAndValidBestStatus.value ?? '')))) {
 
           const allDurs = [getStatusResponse._data.elapsed_time]

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -431,10 +431,10 @@ onMounted(async () => {
       if (validationControlStatus?.value) {
         validControlAndValidBestStatus.value = getValidControlAndValidBestStatus(validationControlStatus.value, validationBestStatus.value);
       }
-    }
     
     // always update the iteration number for any status other than Saved or Ready
     updateIteration();
+    }
   });
 });
 

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -302,7 +302,7 @@ const populatePlotListOptions = async() => {
     logListOptions.value = [];
 
     nextTick(async () => {
-      if (userCalibrationRunData?.value?.status != 'Failed' && (userCalibrationRunData?.value?.status != 'Running' || (iteration.value && iteration.value >= 1))) {
+      if (iteration.value && iteration.value >= 1) {
         // Get Plot Names
         plotNames.value = await queryGetPlotNames();
 

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -215,7 +215,7 @@ import { useUserDataStore } from '@/stores/common/UserDataStore';
 import { generalStore } from "~/stores/common/GeneralStore";
 
 import { ValidationPlotNames } from "@/composables/NgencerfEnums";
-import { isValidDate, isNotNullOrUndefined } from '@/utils/CommonHelpers';
+import { isCalibrationJobStatusSavedOrReady, isValidDate, isNotNullOrUndefined } from '@/utils/CommonHelpers';
 import { formatDateForRunOnString, calculateElapsedTime, sumAndFormatElapsedTimes } from '@/utils/TimeHelpers';
 
 import { hilightTab } from '@/composables/TabHilight';
@@ -263,6 +263,7 @@ const {
   runCalibrationJob,
   queryGetIteration,
   cancelCalibrationJob,
+  cancelValidationJob,
   queryGetLogNames,
   queryGetLogData,
   queryGetLogStatus
@@ -396,8 +397,8 @@ onMounted(async () => {
       }
     }
 
-    // if calibration is Done, check if all validation statuses are Done
-    if (userCalibrationRunData?.value?.status === 'Done') {
+    // if calibration is not Saved or Ready, check validation statuses
+    if (!isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.value?.status)) {
       const getStatusResponse = await queryGetCalibrationStatus(userCalibrationRunData?.value?.calibration_run_id as number);
       const validations = getStatusResponse?._data?.validations;
 
@@ -432,11 +433,8 @@ onMounted(async () => {
       }
     }
     
-    if (userCalibrationRunData.value?.status === 'Running' || 
-      (userCalibrationRunData.value?.status === 'Done' &&
-      (!validControlAndValidBestStatus.value || ['Submitted', 'Ready', 'Running'].includes(validControlAndValidBestStatus.value ?? '')))) {
-      updateIteration();
-    }
+    // always update the iteration number for any status other than Saved or Ready
+    updateIteration();
   });
 });
 
@@ -519,9 +517,23 @@ const startRun = async () => {
 
 // Cancel Calibration Job
 const cancelRun = async () => {
-  if (calibrationStatus.value === 'Running'  || validationControlStatus.value === 'Running' || validationBestStatus.value === 'Running') {
+  if (calibrationStatus.value === 'Running' || validationControlStatus.value === 'Running' || validationBestStatus.value === 'Running') {
     try {
-      const cancelCalibrationResponse = await cancelCalibrationJob();
+      let cancelCalibrationResponse = undefined;
+      if (calibrationStatus.value === 'Running') {
+        cancelCalibrationResponse = await cancelCalibrationJob();
+      } else {
+        // get validations
+        const getStatusResponse = await queryGetCalibrationStatus(userCalibrationRunData?.value?.calibration_run_id as number);
+        const validations = getStatusResponse?._data?.validations;
+        if (validationControlStatus.value === 'Running') {
+          const validControl = validations?.find((validation: any) => validation.validation_type === 'valid_control');
+          cancelCalibrationResponse = await cancelValidationJob(validControl.validation_run_id);
+        } else {
+          const validBest = validations?.find((validation: any) => validation.validation_type === 'valid_best');
+          cancelCalibrationResponse = await cancelValidationJob(validBest.validation_run_id);
+        }
+      }
 
       if (cancelCalibrationResponse?._data.status) {
         if (userCalibrationRunData.value) {

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -295,7 +295,7 @@ const selectedLogStatus = ref<DynamicObject>({});
 let logTimeout;
 
 const populatePlotListOptions = async() => {
-  if (userCalibrationRunData?.value?.calibration_run_id > 0 && !(['Saved','Ready','Validating and Preparing Job Data','Submitted'].includes(userCalibrationRunData?.value?.status))) {
+  if (userCalibrationRunData?.value?.calibration_run_id > 0 && !isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.value?.status)) {
     plotList.value = [];
     plotList.value.push({ name: plotListDefault.value, display_name: '' });
     plotListOptions.value = [];
@@ -433,7 +433,8 @@ onMounted(async () => {
       }
     
     // always update the iteration number for any status other than Saved or Ready
-    updateIteration();
+    await updateIteration();
+    await populatePlotListOptions();
     }
   });
 });
@@ -986,6 +987,7 @@ const gotoEvaluation = () => {
 
 onUnmounted(() => {
   // make sure page clears all selected plots/tables when the user leaves
+  iteration.value = undefined;
   plotList.value = [];
   resetUserPlotRefs([]);
 })

--- a/layouts/CalibrationLayout.vue
+++ b/layouts/CalibrationLayout.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { onUnmounted } from "vue";
+import { onMounted, onUnmounted } from "vue";
 import AppFooter from "@/components/Common/AppFooter.vue";
 import AppHeader from "@/components/Common/AppHeader.vue";
 import CalibrationRightBlock from "@/components/Calibration/CalibrationRightBlock.vue";
@@ -60,6 +60,11 @@ import CalibrationLeftBlock from "@/components/Calibration/CalibrationLeftBlock.
 import { generalStore } from "@/stores/common/GeneralStore";
 
 const { getMenuIndex, getCalibrationTabIndex, setCalibrationTabIndex } = generalStore();
+
+onMounted (() => {
+  console.log('getMenuIndex:', getMenuIndex());
+  console.log('getCalibrationTabIndex:', getCalibrationTabIndex());
+})
 
 onUnmounted(() => {
   // Reset tab index to 1 when we leave this layout, 

--- a/stores/calibration/RunStatusStore.ts
+++ b/stores/calibration/RunStatusStore.ts
@@ -290,6 +290,21 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
       body: JSON.stringify({ calibration_run_id: calibrationJobId.value })
     });
   };
+
+  /**
+   * Cancel Validation Job
+   * @returns {any}
+   */
+  const cancelValidationJob = async (validation_run_id: number): Promise<any> => {
+    return makeProtectedApiCall<any>(`${ngencerfBaseUrl}/calibration/cancel_job/`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${getAccessToken()}`,
+        "Content-Type": 'application/json'
+      },
+      body: JSON.stringify({ validation_run_id: validation_run_id })
+    });
+  };
   
   /**
     * Get Calibration Log Names
@@ -420,6 +435,7 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
     runCalibrationJob,
     queryGetIteration,
     cancelCalibrationJob,
+    cancelValidationJob,
     queryGetLogNames,
     queryGetLogData,
     queryGetLogStatus,


### PR DESCRIPTION
Don't show spinny icon when submitting job (so that user can navigate away and work on other things while waiting)

Note that this does NOT allow cancellation during the setup phase before job status changes to "Running". That will need to be handled on the backend.