### PR TITLE
Properly default AET Rootzone checkbox for both true and false values

### DIFF
--- a/stores/calibration/FormulationStore.ts
+++ b/stores/calibration/FormulationStore.ts
@@ -81,9 +81,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
     } else {
         selectedModuleValues.value = [];
     }
-    if (userCalibrationRunData.value?.is_aet_rootzone) {
-      isAETRootzone.value = true;
-    }
+    isAETRootzone.value = userCalibrationRunData.value?.is_aet_rootzone ? userCalibrationRunData.value.is_aet_rootzone : false;
     useSlothParameters.value = userCalibrationRunData.value?.use_sloth ?? false;
     slothParameterInputs.value =
       JSON.parse(


### PR DESCRIPTION
To test: Go to a saved job where rootzone is set to true, leave, then go to another saved job where rootzone is false. Leave and go back to the previous job. Make sure rootzone is properly checked/unchecked in all cases.