### PR TITLE
Dwmartin run status cancel fix

### DIFF
--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -328,7 +328,6 @@ const populatePlotListOptions = async() => {
 
       if (!['Submitted','Validating and Preparing Job Data'].includes(userCalibrationRunData?.value?.status)) {
         // Get Names of available Logs
-        console.log('Status when requesting log names: ', userCalibrationRunData?.value?.status);
         logs.value = await queryGetLogNames(
           (userCalibrationRunData?.value?.calibration_run_id) ? userCalibrationRunData?.value?.calibration_run_id : 0 // validation_run_id
         );
@@ -417,7 +416,6 @@ onMounted(async () => {
 
     // if calibration is not Saved or Ready, check validation statuses
     if (!isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.value?.status)) {
-      const getStatusResponse = await queryGetCalibrationStatus(userCalibrationRunData?.value?.calibration_run_id as number);
       const validations = getStatusResponse?._data?.validations;
 
       const validControl = validations?.find((validation: any) => validation.validation_type === 'valid_control');
@@ -593,7 +591,9 @@ const updateIteration = async () => {
       }
     }
     userCalibrationRunData.value.status = getIterationResponse._data.status;
-    userCalibrationRunData.value.failure_messages = getIterationResponse._data.failure_messages;
+    if (getIterationResponse._data.failure_messages) {
+      userCalibrationRunData.value.failure_messages = getIterationResponse._data.failure_messages;
+    }
   } else {
     const tMsg: ToastMessageOptions = { severity: 'warn', summary: 'Unable to get Calibration Job Status', life: ToastTimeout.timeoutWarn };
     toast.add(tMsg); addToastRecord(tMsg);

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -326,8 +326,9 @@ const populatePlotListOptions = async() => {
         }
       }
 
-      if (userCalibrationRunData?.value?.status !== 'Submitted') {
+      if (!['Submitted','Validating and Preparing Job Data'].includes(userCalibrationRunData?.value?.status)) {
         // Get Names of available Logs
+        console.log('Status when requesting log names: ', userCalibrationRunData?.value?.status);
         logs.value = await queryGetLogNames(
           (userCalibrationRunData?.value?.calibration_run_id) ? userCalibrationRunData?.value?.calibration_run_id : 0 // validation_run_id
         );
@@ -463,7 +464,7 @@ const createElapsedTimeInterval = () => {
   }
   elapsedTimeIntervalId.value = setInterval(async () => {
     if (
-      ['Validating and Preparing Job Data','Running'].includes(userCalibrationRunData.value?.status) || 
+      ['Validating and Preparing Job Data','Submitted','Running'].includes(userCalibrationRunData.value?.status) || 
       (userCalibrationRunData.value?.status === 'Done' &&
       (!validControlAndValidBestStatus.value || ['Submitted', 'Ready', 'Running'].includes(validControlAndValidBestStatus.value ?? '')))) {
       // Calculate calibrationElapsedTime every second while Calibration is Running or Validation is not Done

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -560,7 +560,6 @@ const cancelRun = async () => {
       if (cancelCalibrationResponse?._data.status) {
         if (userCalibrationRunData.value) {
           userCalibrationRunData.value.status = cancelCalibrationResponse?._data.status;
-          userCalibrationRunData.value.failure_messages = getStatusResponse._data.failure_messages;
         }
         if (userCalibrationRunData?.value?.status !== 'Cancelled') {
           const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Error', detail: 'Calibration status not set to Cancelled after clicking CANCEL', life: ToastTimeout.timeoutError };

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -437,21 +437,19 @@ onMounted(async () => {
         });
         calibrationElapsedTime.value = sumAndFormatElapsedTimes(allDurs);
       }
-
-
-      if (validControl?.status) {
-        validationControlStatus.value = validControl.status;
-      }
-      if (validBest?.status) {
-        validationBestStatus.value = validBest.status;
-      }
-      if (validationControlStatus?.value) {
-        validControlAndValidBestStatus.value = getValidControlAndValidBestStatus(validationControlStatus.value, validationBestStatus.value);
-      }
+      
+      validationControlStatus.value = validControl?.status ? validControl.status : undefined;
+      validationBestStatus.value = validBest?.status ? validBest.status : undefined;
+      validControlAndValidBestStatus.value = validationControlStatus?.value ? getValidControlAndValidBestStatus(validationControlStatus.value, validationBestStatus.value) : undefined;
     
-    // always update the iteration number for any status other than Saved or Ready
-    await updateIteration();
-    await populatePlotListOptions();
+      // always update the iteration number for any status other than Saved or Ready
+      await updateIteration();
+      await populatePlotListOptions();
+    } else {
+      // If job is saved or ready we need to explicitly clear the validation statuses
+      validationControlStatus.value = undefined;
+      validationBestStatus.value = undefined;
+      validControlAndValidBestStatus.value = undefined;
     }
   });
 });
@@ -1017,6 +1015,9 @@ onUnmounted(() => {
   // make sure page clears all selected plots/tables when the user leaves
   iteration.value = undefined;
   plotList.value = [];
+  validationControlStatus.value = undefined;
+  validationBestStatus.value = undefined;
+  validControlAndValidBestStatus.value = undefined;
   resetUserPlotRefs([]);
 })
 </script>


### PR DESCRIPTION
Cancel Button should no longer show up beside Run button when job is Ready.

Elapsed Time counter should not pause when job is in a Submitted State,

get_log_names should not get called prematurely while Validating and Preparing Job Data.

Cancelling the job should result in a Failure Message being shown onscreen instead of a generic Toast error popping up.