### PR TITLE
Add Compare Permutations Help (NGWPC-8648). Fix timeseries key in endpoint response (NGWPC-8758)

### DIFF
--- a/assets/styles/styles.scss
+++ b/assets/styles/styles.scss
@@ -497,7 +497,7 @@ table.cols-bordered {
 
 // Help Pages
 ._help-page {
-  padding: 10px 20px 5px 20px;
+  padding: 5px 5px 5px 5px;
 }
 
 ._help-title {
@@ -509,23 +509,23 @@ table.cols-bordered {
 }
 
 ._help-subtitle {
-    font-size: 14 px;
-    text-align: center;
-  margin: 15px 30px;
-  padding: 0 30px; 
+  font-size: 14 px;
+  text-align: center;
+  margin: 10px 10px;
+  padding: 0 10px; 
 }
 
 ._help-table {
-  margin-top: 20px;
-  margin-left: 20px;
+  margin-top: 5px;
+  margin-left: 5px;
 }
 
 ._help-table .td1 {
   text-align: right;
     width: auto;
-    min-width: 130px;
-  vertical-align: top !important;
-  font-weight: 600;
+    min-width: 200px;
+    vertical-align: top !important;
+    font-weight: 600;
 }
 
 ._help-table .td2 {

--- a/components/Common/AppHeader.vue
+++ b/components/Common/AppHeader.vue
@@ -96,6 +96,9 @@
                                 <span v-if="getEvaluationTabIndex() === 2">
                                     <LazyEvaluationEvaluatesHelp />
                                 </span>
+                                <span v-if="getEvaluationTabIndex() === 3">
+                                    <LazyEvaluationComparePermutationsHelp />
+                                </span>
                                 <span v-if="getEvaluationTabIndex() === 4">
                                     <LazyEvaluationCalibrationSelectAltInterationssHelp />
                                 </span>
@@ -173,6 +176,7 @@ const LazyCalibrationHelpRunStatusHelp = defineAsyncComponent(() => import("@/co
 // Evaluation Workflow Help Files
 const LazyEvaluationCalibrationRunsHelp = defineAsyncComponent(() => import("@/components/Help/Evaluation/CalibrationRunsHelp.vue"))
 const LazyEvaluationEvaluatesHelp = defineAsyncComponent(() => import("@/components/Help/Evaluation/EvaluateHelp.vue"))
+const LazyEvaluationComparePermutationsHelp = defineAsyncComponent(() => import("@/components/Help/Evaluation/ComparePermutationsHelp.vue"))
 const LazyEvaluationCalibrationSelectAltInterationssHelp = defineAsyncComponent(() => import("@/components/Help/Evaluation/SelectAltIterationHelp.vue"))
 const LazyEvaluationRunStatusHelp = defineAsyncComponent(() => import("@/components/Help/Evaluation/RunStatusHelp.vue"))
 

--- a/components/Evaluation/ComparePermutationsTab.vue
+++ b/components/Evaluation/ComparePermutationsTab.vue
@@ -124,7 +124,7 @@ const cmCompareRun = ref<DataTableContextMenuOption[]>([]);
 
 const selectedSupplementalTable = ref<number>(0);
 const supplementalTableOptions = ref<any[]>([
-  'Performance Metrics Table'
+  'Performance Metrics'
 ]);
 const performanceMetrics = ref<APIResponse>({});
 const performanceMetricsData = ref<any[]>([]);

--- a/components/Evaluation/EvaluateTab.vue
+++ b/components/Evaluation/EvaluateTab.vue
@@ -735,9 +735,9 @@ watch(selectedPlotName, async () => {
         const response: any = await queryGetSWETimeseriesData(
           (evaluateValidationRunId.value) ? evaluateValidationRunId.value : 0, // validation_run_id
         );
-        if (response?._data?.swe_timeseries_data) {
+        if (response?._data?.timeseries_data) {
           // get time series data from server
-          sweTimeSeriesData.value = response?._data?.swe_timeseries_data;
+          sweTimeSeriesData.value = response?._data?.timeseries_data;
           selectedPlotHasTimeseries.value = true;
           // Start with SWE timeseries already displayed
           togglePlotGraph();

--- a/components/Help/Evaluation/ComparePermutationsHelp.vue
+++ b/components/Help/Evaluation/ComparePermutationsHelp.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="_help-page">
+    <div class="_help-title">Evaluation - Compare Permutations Tab</div>
+    <div class="_help-subtitle">This tab provides the ability to compare perumations.</div>
+    <p class="text-center" style="color:#cc5500;font-size:0.8em;">
+      WARNING: Clicking the browser refresh button takes you to the Calibration Runs tab.
+    </p>
+    <hr />
+    <div>
+      <table class="_help-table" aria-label="Evaluation Run/Status Help Table">
+        <thead>
+            <tr>
+            <th>&nbsp;</th>
+            <th>&nbsp;</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+              <td class="td1">Display</td>
+              <td class="td2">Select comparison to view.</td>
+            </tr>
+            <tr>
+              <td class="td1 col-span-2">&nbsp;</td>
+            </tr>
+            <tr>
+              <td class="td1">Calibration Metrics</td>
+              <td class="td2">Displays 3 tables of best run metrics for comparison.</td>
+            </tr>
+            <tr>
+              <td class="td1" style="font-weight: normal;">Calibration Period</td>
+              <td class="td2">Calib Start Time to Calib End Time</td>
+            </tr>
+            <tr>
+              <td class="td1" style="font-weight: normal;">Validation Period</td>
+              <td class="td2">Validation Start Time to Validation End Time</td>
+            </tr>
+            <tr>
+              <td class="td1" style="font-weight: normal;">Full Period Period</td>
+              <td class="td2">Earliest of Calibration and Validation Start Times to<br />
+                              Latest of Validation and Validation End Times</td>
+            </tr>
+            <tr>
+              <td class="td1">Performance Metrics</td>
+              <td class="td2">Displays the performance metrics for comparison.</td>
+            </tr>
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Elapsed Time</td>
+              <td class="td2">The job's elapsed time</td>
+            </tr>              
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Num Cpus</td>
+              <td class="td2">Total number of CPUs allocated to the job</td>
+            </tr>              
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Cpu Time</td>
+              <td class="td2">Elapsed time * CPU count</td>
+            </tr>              
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Max Rss</td>
+              <td class="td2">Maximum resident set size of all tasks in job</td>
+            </tr>              
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Max Disk Read</td>
+              <td class="td2">Maximum number of bytes read by all tasks in job</td>
+            </tr>              
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Max Disk Write</td>
+              <td class="td2">Maximum number of bytes written by all tasks in job</td>
+            </tr>              
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Reserved Time</td>
+              <td class="td2">How much wall clock time was used as planned time for this
+                              job. This is derived from how long a job was waiting in PW from eligible time to
+                              when it started or was cancelled.</td>
+            </tr>              
+            <tr>
+              <td class="td1"  style="font-weight: normal;">Io Throughput</td>
+              <td class="td2">Computed: (Max Disk Read + Max Disk Write) / Elapsed Time</td>
+            </tr>              
+        </tbody>
+      </table>
+    </div>
+    <p style="margin-top:12px;font-size: 0.9em;">
+      <strong>Note:</strong><br />
+      <em>Elapsed time fields are presented as</em> [days-]hours:minutes:seconds[.microseconds]</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+
+</script>
+
+<style lang="scss" scoped>
+@use "@/assets/styles/global.scss";
+@use "@/assets/styles/styles.scss";
+</style>


### PR DESCRIPTION
Added the missing helpfile for compare permutations.

When adding the Soil Moisture timeseries endpoint, Peter made the times series key in the endpoint response more generic. So instead of it returning `swe_timeseries_data` it returned `timeseries_data`. Updated the UI to expect `timeseries_data`.

Successfully tested and able to view SWE timeseries data and images.