### PR TITLE
Dwmartin ngwpc 8421 module metric display names

### DIFF
--- a/components/Calibration/Formulation.vue
+++ b/components/Calibration/Formulation.vue
@@ -27,13 +27,13 @@
             </div>
             <div class="pt-4 mb-1 font-bold text-base">Select Modules</div>
             <Listbox id="ModuleList" v-model="selectedModuleValues" :options="fetchFormulationModuleOptions" multiple
-              optionLabel="name" optionValue="name" class="h-60" @change="moduleListChanged"
+              optionLabel="display_name" optionValue="name" class="h-60" @change="moduleListChanged"
               :disabled="!isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.status)">
               <template #option="slotProps">
                 <div v-bind:class="(slotProps.option.selected === true) ? 'pi pi-check font-bold' : 'pl-5'">
                   <div class="font-ui pl-2 leading-none" :aria-label="slotProps.option.name"
                     :title="slotProps.option.name">
-                    {{ slotProps.option.name }}</div>
+                    {{ slotProps.option.display_name }}</div>
                 </div>
 
               </template>

--- a/components/Calibration/OptimizationMetrics.vue
+++ b/components/Calibration/OptimizationMetrics.vue
@@ -56,7 +56,7 @@
             <div id="ObjFunct">
               <label for="ObjectiveFunction<">Objective Function</label>
               <Select id="ObjectiveFunction" class="rounded-md" filter v-model="uiObjectiveFunction"
-                :options="getObjectiveFunctionOptionsList" optionLabel="name" optionValue="name" placeholder=""
+                :options="getObjectiveFunctionOptionsList" optionLabel="display_name" optionValue="name" placeholder=""
                 @change="updateMetricFlowFieldVisibility" aria-label="Objective Function" title="Objective Function"
                 :disabled="!isCalibrationJobStatusSavedOrReady(userCalibrationRunData?.status)"></Select>
               <div v-if="showObjectiveFunctionStreamFlow" class="ml-3 mt-2">

--- a/components/Common/EvalRunsFilterDialog.vue
+++ b/components/Common/EvalRunsFilterDialog.vue
@@ -19,7 +19,7 @@
             <label for="ModuleList" class="block text-left mb-1" aria-label="Module Filter"
               title="Module Filter">Modules</label>
             <MultiSelect id="ModuleList" v-model="modulesFilterList" :options="fetchFormulationModuleOptions"
-              optionLabel="name" optionValue="name" :maxSelectedLabels="3" class="JobsFilterSelect w-full" aria-label="Module Filter"
+              optionLabel="display_name" optionValue="name" :maxSelectedLabels="3" class="JobsFilterSelect w-full" aria-label="Module Filter"
               title="Module Filter" :disabled="disableAll">
               <template #header>
                 <div class="absolute cursor-pointer top-2 left-[38px]">&nbsp; Select All Items</div>
@@ -27,7 +27,7 @@
               <template #option="slotProps">
                 <div class="font-ui pl-2 leading-none" :aria-label="slotProps.option.name"
                   :title="slotProps.option.name">
-                  {{ slotProps.option.name }}&nbsp;
+                  {{ slotProps.option.display_name }}&nbsp;
                 </div>
               </template>
             </MultiSelect>

--- a/components/Common/JobFilterDialog.vue
+++ b/components/Common/JobFilterDialog.vue
@@ -37,7 +37,7 @@
             <label for="ModuleList" class="block text-left mb-1" aria-label="Module Filter"
               title="Module Filter">Modules</label>
             <MultiSelect id="ModuleList" v-model="modulesFilterList" :options="fetchFormulationModuleOptions"
-              optionLabel="name" optionValue="name" :maxSelectedLabels="3" class="JobsFilterSelect w-full" aria-label="Module Filter"
+              optionLabel="display_name" optionValue="name" :maxSelectedLabels="3" class="JobsFilterSelect w-full" aria-label="Module Filter"
               title="Module Filter" :disabled="disableAll">
               <template #header>
                 <div class="absolute cursor-pointer top-2 left-[38px]">&nbsp; Select All Items</div>
@@ -45,7 +45,7 @@
               <template #option="slotProps">
                 <div class="font-ui pl-2 leading-none" :aria-label="slotProps.option.name"
                   :title="slotProps.option.name">
-                  {{ slotProps.option.name }}&nbsp;
+                  {{ slotProps.option.display_name }}&nbsp;
                 </div>
               </template>
             </MultiSelect>

--- a/components/Common/MessagesGroup.vue
+++ b/components/Common/MessagesGroup.vue
@@ -183,6 +183,7 @@
 import { storeToRefs } from 'pinia';
 
 import { useUserDataStore } from '@/stores/common/UserDataStore';
+import { useFormulationStore } from "@/stores/calibration/FormulationStore";
 import { useTuningStore } from "@/stores/calibration/TuningStore";
 import { useRunStatusStore } from '@/stores/calibration/RunStatusStore';
 
@@ -190,6 +191,7 @@ import { formatISOStringOrDateToYYYYMMDDHHMM } from '@/utils/TimeHelpers';
 
 const { userCalibrationRunData, calibrationJobNgenGlobalLogging } = storeToRefs(useUserDataStore());
 const calData = ref(userCalibrationRunData);
+const { fetchFormulationModuleOptions } = useFormulationStore();
 const {
   userSelectedCalibrationTuningParameters,
   selectedOutputVariableToCalibrate,
@@ -206,9 +208,12 @@ const componentProps = withDefaults(defineProps<{
 const getModuleList = () => {
   let modules = "";
   calData.value?.modules.forEach(element => {
-    modules += element;
-    if (calData.value?.modules[calData.value?.modules.length - 1] !== element) {
-      modules += ", ";
+    let module_option = fetchFormulationModuleOptions.find(module => module.name === element);
+    if (module_option) {
+      modules += module_option.display_name;
+      if (calData.value?.modules[calData.value?.modules.length - 1] !== element) {
+        modules += ", ";
+      }
     }
   });
   return modules;

--- a/components/Evaluation/EvaluateTab.vue
+++ b/components/Evaluation/EvaluateTab.vue
@@ -200,6 +200,12 @@
           <DataTable :value="iterationMetricsData" scrollable scroll-height="500px" fixedHeader=true :multi-sort="true">
             <Column v-for="(col, colIndex) in iterationMetricsColumns" :key="colIndex" :header="col.header"
               :field="col.field" sortable></Column>
+              <!-- should be able to have col.tooltip show up as a tooltip here -->
+              <!-- <template #header="slotProps">
+                <div class="column-header">
+                  {{ slotProps.column.props.header }}
+                </div>
+              </template> -->
           </DataTable>
         </div>
         <div v-if="iterationParamsData && selectedSupplementalTable === 2">
@@ -570,7 +576,7 @@ watch(selectedPlotName, async () => {
         }
 
         // set up array for iterationMetricsData
-        iterationMetricsColumns.value = [{ header: 'Iteration', field: 'iteration' }];
+        iterationMetricsColumns.value = [{ header: 'Iteration', field: 'iteration', tooltip: 'Iteration' }];
         if (iterations.value?._data?.iteration_data) {
           for (let i = 0; i < iterations.value?._data?.iteration_data?.length; i++) {
             const iterationMetricsRecord: DynamicObject = {};
@@ -584,7 +590,8 @@ watch(selectedPlotName, async () => {
                 iterationMetricsRecord[metric_name] = iterationMetricsRecord[metric_name].toFixed(5);
               }
               if (i === 0) {
-                iterationMetricsColumns.value.push({ header: metric_name, field: metric_name });
+                let metric_display_name = iterations.value?._data?.iteration_data[i].metrics[m].metric_display_name;
+                iterationMetricsColumns.value.push({ header: metric_name, field: metric_name, tooltip: metric_display_name });
               }
             }
             iterationMetricsData.value.push(iterationMetricsRecord);

--- a/components/Evaluation/SelectAltIterationTab.vue
+++ b/components/Evaluation/SelectAltIterationTab.vue
@@ -11,7 +11,14 @@
           <ColumnGroup type="header">
             <Row>
               <Column v-for="( col, colIndex ) in calibrationRunDetailTableColumn" :key="colIndex" :header="col.header"
-                :field="col.field" :hidden="col.hidden ?? false" :class="col.styles ?? []" sortable></Column>
+                :field="col.field" :hidden="col.hidden ?? false" :class="col.styles ?? []" sortable>
+                <!-- should be able to have col.tooltip show up as a tooltip here -->
+                <!-- <template #header="slotProps">
+                  <div class="column-header">
+                    {{ slotProps.column.props.header }}
+                  </div>
+                </template> -->
+              </Column>
             </Row>
             <Row v-for="(row, index) in calibrationRunDetailDataListHeaders" :key="index" :pt="{ id: index }">
               <Column v-for="( col, colIndex ) in row" :key="colIndex" :header="col.header" :class="col.styles ?? []" :colspan="col.colspan">

--- a/composables/NgencerfModels.ts
+++ b/composables/NgencerfModels.ts
@@ -182,6 +182,7 @@ export interface UserCalibrationRunData {
   save_output_iteration: boolean;
   stop_criteria: number;
   status: string;
+  failure_messages: any;
 }
 
 export interface FormulationWarning {
@@ -324,6 +325,7 @@ export interface FormulationTabData {
 
 export interface FormulationModuleData {
   name: string;
+  display_name: string;
   groups: string[];
   used_by_calibration_run: boolean;
 }
@@ -378,6 +380,7 @@ export interface tuning_save {
  */
 export interface SelectOption {
   name: string;
+  display_name: string;
   description: string;
   selected?: boolean;
   groups?: string[];
@@ -436,6 +439,7 @@ export interface OptimizationTabData {
 
 export interface OptimizationMetricData {
   name: string;
+  display_name: string;
   description: string;
   is_active: boolean;
   categorical: boolean;
@@ -561,6 +565,7 @@ export interface DynamicTableColumn {
   header?: string;
   hidden?: boolean;
   styles?: string[];
+  tooltip?: string;
 }
 
 export interface CalibrationRunByIteration {
@@ -598,6 +603,7 @@ export interface CalibrationRunByIterationRetrospectiveData {
 
 export interface CalibrationRunIterationMetricData {
   metric_name: string;
+  metric_display_name: string;
   metric_value: number;
 }
 
@@ -636,6 +642,7 @@ export interface CalibrationGetStatusResponse {
   submit_date: Date;
   elapsed_time: string | null;
   performance_metrics: CalibrationGetStatusPerformanceMetricItem[] | null;
+  failure_messages: any;
 }
 
 export interface CalibrationGetStatusValidationItem {
@@ -648,6 +655,7 @@ export interface CalibrationGetStatusValidationItem {
   run_start: Date;
   elapsed_time?: string | null;
   performance_metrics?: CalibrationGetStatusPerformanceMetricItem[] | null;
+  failure_messages: any;
 }
 
 export interface CalibrationGetStatusPerformanceMetricItem {

--- a/layouts/CalibrationLayout.vue
+++ b/layouts/CalibrationLayout.vue
@@ -61,11 +61,6 @@ import { generalStore } from "@/stores/common/GeneralStore";
 
 const { getMenuIndex, getCalibrationTabIndex, setCalibrationTabIndex } = generalStore();
 
-onMounted (() => {
-  console.log('getMenuIndex:', getMenuIndex());
-  console.log('getCalibrationTabIndex:', getCalibrationTabIndex());
-})
-
 onUnmounted(() => {
   // Reset tab index to 1 when we leave this layout, 
   // so that it doesn't try to mount the wrong tab when you return

--- a/stores/calibration/FormulationStore.ts
+++ b/stores/calibration/FormulationStore.ts
@@ -95,7 +95,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
    */
   const fetchFormulationModuleOptions = computed(() => {
     let modules_list = <SelectOption[]>[];
-    let selected_mouldes_list = <SelectOption[]>[];
+    let selected_modules_list = <SelectOption[]>[];
     if (
       formulationTabData.value?.modules &&
       formulationTabData.value?.modules.length > 0
@@ -107,12 +107,13 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
         ) {
           const selectOptionItem = {
             name: moduleData.name,
-            description: moduleData.name,
+            display_name: moduleData.display_name,
+            description: moduleData.display_name,
             selected: false,
             groups: moduleData.groups,
           };
           if (userCalibrationRunData?.value?.modules?.includes(moduleData.name)) {
-            selected_mouldes_list.push(selectOptionItem);
+            selected_modules_list.push(selectOptionItem);
           } else {
             modules_list.push(selectOptionItem);
           }
@@ -120,7 +121,7 @@ export const useFormulationStore = defineStore("FormulationStore", () => {
       });
     }
 
-    return selected_mouldes_list
+    return selected_modules_list
       .slice()
       .sort((a, b) => a.name.localeCompare(b.name))
       .concat(

--- a/stores/calibration/OptimizationStore.ts
+++ b/stores/calibration/OptimizationStore.ts
@@ -113,7 +113,8 @@ export const useOptimizationStore = defineStore(
       optimizationTabData.value?.metrics.forEach((metric_option) => {
         objectiveFunctionOptionsList.value.push({
           name: metric_option.name,
-          description: metric_option.name,
+          display_name: metric_option.display_name,
+          description: metric_option.display_name,
           selected: false,
           groups: [],
         });

--- a/stores/evaluation/EvaluationAltIterationStore.ts
+++ b/stores/evaluation/EvaluationAltIterationStore.ts
@@ -68,6 +68,7 @@ export const useEvaluationAltIterationStore = defineStore(
                   header: `${Number(data.metric_value).toFixed(4)}`,
                   colspan: 1,
                   metric_name: data.metric_name,
+                  metric_display_name: data.metric_display_name,
                   styles: []
                 }
                 headerRow.push(headerCell);
@@ -130,11 +131,13 @@ export const useEvaluationAltIterationStore = defineStore(
                   let headerColumn = <DynamicTableColumn>{
                     field: metric.metric_name,
                     header: metric_header_label,
+                    tooltip: metric.metric_display_name,
                   };
                   let headerCell = {
                     header: `${Number(metric.metric_value).toFixed(4)}`,
                     colspan: 1,
                     metric_name: metric.metric_name,
+                    metric_display_name: metric.metric_display_name,
                     styles: [],
                   }
                   if (


### PR DESCRIPTION
Show verbose module names on the following pages:
- Calibration Runs List and Evaluation Runs List (in the module filter dropdown)
- Formulation Tab
- Calibration Details (in the right panel)

Show verbose metric names on the Optimization Metrics tab.

Display of metric names on the Evaluate and Select Alternate Iteration tabs is still TBD, since those are table column headers.