### PR TITLE
Don't allow deletion/archival of running jobs

### DIFF
--- a/components/Calibration/PreviousCalibrationRuns.vue
+++ b/components/Calibration/PreviousCalibrationRuns.vue
@@ -338,13 +338,13 @@ const buildContextMenu = computed(() => {
   } else {
     contextMenuOptions.push(cmOpenRun.value);
     contextMenuOptions.push(cmCloneRun.value);
-    if (selectedCalibrationRun?.value?.status !== 'Running') {
+    if (!selectedCalibrationRun?.value?.status.includes('Submitted') && !selectedCalibrationRun?.value?.status.includes('Running')) {
       if (selectedCalibrationRun?.value?.is_downloadable) {
         contextMenuOptions.push(cmDownloadRun.value);
       }
     }
     contextMenuOptions.push(cmExportRun.value);
-    if (selectedCalibrationRun?.value?.status !== 'Running') {
+    if (!selectedCalibrationRun?.value?.status.includes('Submitted') && !selectedCalibrationRun?.value?.status.includes('Running')) {
       if (!selectedCalibrationRun?.value?.is_locked) {
         contextMenuOptions.push(cmDeleteRun.value);
       }
@@ -788,9 +788,28 @@ const acceptDelete = (selectedRunId: number) => {
   deleteCalibrationRun(selectedRunId).then(async (response) => {
     toast.removeAllGroups();
     if (response.status === 200) {
-      const tMsg: ToastMessageOptions = { severity: 'success', 
-        summary: 'Calibration Job Deleted', detail: 'Job ' + selectedRunId + ' deleted', life: ToastTimeout.timeoutSuccess };
-      toast.add(tMsg); addToastRecord(tMsg);
+      let successMessages: string[] = [];
+      let failureMessages: string[] = [];
+      response._data?.jobs.forEach(job => {
+        if (job.success) {
+          successMessages.push(job.message);
+        } else {
+          failureMessages.push(job.message);
+        }
+      });
+      toast.removeAllGroups();
+      if (successMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'success', 
+          summary: 'Delete Job', detail: successMessages.join('\n'), 
+          life: ToastTimeout.timeoutSuccess};
+        toast.add(tMsg); addToastRecord(tMsg);
+      }
+      if (failureMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'error', 
+          summary: 'Delete Job', detail: failureMessages.join('\n'), 
+          life: ToastTimeout.timeoutError};
+        toast.add(tMsg); addToastRecord(tMsg);
+      }
       await fetchUserCalibrationJobsListData();
       // populate updatedUserCalibrationJobsListData with the job statuses to include the validation status
       await updateUserCalibrationJobsListData();
@@ -855,9 +874,28 @@ const acceptArchive = (selectedRunId: number, archiveJob: boolean) => {
   archiveCalibrationRun(selectedRunId, archiveJob).then(async (response) => {
     toast.removeAllGroups();
     if (response.status === 200) {
-      const tMsg: ToastMessageOptions = { severity: 'success', 
-        summary: 'Calibration Job ' + (archiveJob ? 'Archived' : 'Un-Archived'), detail: 'Job ' + selectedRunId + ' ' + (archiveJob ? 'Archived' : 'Un-Archived'), life: ToastTimeout.timeoutSuccess };
-      toast.add(tMsg); addToastRecord(tMsg);
+      let successMessages: string[] = [];
+      let failureMessages: string[] = [];
+      response._data?.jobs.forEach(job => {
+        if (job.success) {
+          successMessages.push(job.message);
+        } else {
+          failureMessages.push(job.message);
+        }
+      });
+      toast.removeAllGroups();
+      if (successMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'success', 
+          summary: (archiveJob ? 'Archive' : 'Un-Archive') + ' Job', detail: successMessages.join('\n'), 
+          life: ToastTimeout.timeoutSuccess};
+        toast.add(tMsg); addToastRecord(tMsg);
+      }
+      if (failureMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'error', 
+          summary: (archiveJob ? 'Archive' : 'Un-Archive') + ' Job', detail: failureMessages.join('\n'), 
+          life: ToastTimeout.timeoutError};
+        toast.add(tMsg); addToastRecord(tMsg);
+      }
       await fetchUserCalibrationJobsListData();
       // populate updatedUserCalibrationJobsListData with the job statuses to include the validation status
       await updateUserCalibrationJobsListData();

--- a/components/Calibration/PreviousCalibrationRuns.vue
+++ b/components/Calibration/PreviousCalibrationRuns.vue
@@ -335,7 +335,7 @@ const buildContextMenu = computed(() => {
   let contextMenuOptions = [];
   if (selectedCalibrationRun?.value?.is_archived) {
     contextMenuOptions.push(cmUnarchiveRun.value);
-  } else {
+  } else if (selectedCalibrationRun?.value && selectedCalibrationRun?.value?.status) {
     contextMenuOptions.push(cmOpenRun.value);
     contextMenuOptions.push(cmCloneRun.value);
     if (!selectedCalibrationRun?.value?.status.includes('Submitted') && !selectedCalibrationRun?.value?.status.includes('Running')) {

--- a/components/Evaluation/EvaluationRunsTab.vue
+++ b/components/Evaluation/EvaluationRunsTab.vue
@@ -125,6 +125,7 @@
                   :aria-label="'Job ID ' + slotProps.data.calibration_run_id"
                   :title="'Job ID ' + slotProps.data.calibration_run_id">
                   {{ slotProps.data.calibration_run_id }}
+                  <span v-if="slotProps.data.is_locked" class="pi pi-lock"></span>
                 </span>
               </template></Column>
 
@@ -537,8 +538,10 @@ const onRowContextMenu = (event: any) => {
       cmCalibrationRun.value.push({ label: 'Download Results', icon: 'pi pi-download', command: () => downloadSelectedCalibrationData() });
     }
     cmCalibrationRun.value.push({ label: 'Export Calibration Config', icon: 'pi pi-file-export', command: () => exportSelectedCalibrationData() });
-    cmCalibrationRun.value.push({ label: 'Delete', icon: 'pi pi-trash', command: () => deleteSelectedCalibrationRun() });
-    if (!selectedCalibrationRun.value?.is_archived) {
+    if (!selectedCalibrationRun?.value?.status.includes('Submitted') && !selectedCalibrationRun?.value?.status.includes('Running') && !selectedCalibrationRun?.value?.is_locked) {
+      cmCalibrationRun.value.push({ label: 'Delete', icon: 'pi pi-trash', command: () => deleteSelectedCalibrationRun() });
+    }
+    if (!selectedCalibrationRun?.value?.status.includes('Submitted') && !selectedCalibrationRun?.value?.status.includes('Running') && !selectedCalibrationRun.value?.is_archived) {
       cmCalibrationRun.value.push({ label: 'Archive', icon: 'pi pi-folder', command: () => archiveSelectedCalibrationRun(true) });
     }
   }
@@ -793,9 +796,28 @@ const deleteSelectedCalibrationRun = () => {
 const acceptDelete = (selectedRunId: number) => {
   deleteCalibrationRun(selectedRunId).then(response => {
     if (response.status === 200) {
-      const tMsg: ToastMessageOptions = { severity: useApiResponseToastSeverityCode(response?.status), 
-      summary: 'Delete Calibration Run', detail: 'Job ' + selectedRunId + ' deleted', life: useApiResponseToastSeverityLife(response?.status)};
-      toast.add(tMsg); addToastRecord(tMsg);   
+      let successMessages: string[] = [];
+      let failureMessages: string[] = [];
+      response._data?.jobs.forEach(job => {
+        if (job.success) {
+          successMessages.push(job.message);
+        } else {
+          failureMessages.push(job.message);
+        }
+      });
+      toast.removeAllGroups();
+      if (successMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'success', 
+          summary: 'Delete Job', detail: successMessages.join('\n'), 
+          life: ToastTimeout.timeoutSuccess};
+        toast.add(tMsg); addToastRecord(tMsg);
+      }
+      if (failureMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'error', 
+          summary: 'Delete Job', detail: failureMessages.join('\n'), 
+          life: ToastTimeout.timeoutError};
+        toast.add(tMsg); addToastRecord(tMsg);
+      } 
       fetchUserValidatedCalibrationJobsListData();
       resetUserSelectedEvalValidationRun();
     } else {
@@ -893,9 +915,28 @@ const archiveSelectedCalibrationRun = () => {
 const acceptArchive = (selectedRunId: number) => {
   archiveCalibrationRun(selectedRunId, true).then(async (response) => {
     if (response.status === 200) {
-      const tMsg: ToastMessageOptions = { severity: 'success', 
-        summary: 'Calibration Job Archived', detail: 'Job ' + selectedRunId + ' Archived', life: ToastTimeout.timeoutSuccess };
-      toast.add(tMsg); addToastRecord(tMsg);
+      let successMessages: string[] = [];
+      let failureMessages: string[] = [];
+      response._data?.jobs.forEach(job => {
+        if (job.success) {
+          successMessages.push(job.message);
+        } else {
+          failureMessages.push(job.message);
+        }
+      });
+      toast.removeAllGroups();
+      if (successMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'success', 
+          summary: 'Archive Job', detail: successMessages.join('\n'), 
+          life: ToastTimeout.timeoutSuccess};
+        toast.add(tMsg); addToastRecord(tMsg);
+      }
+      if (failureMessages.length > 0) {
+        const tMsg: ToastMessageOptions = { severity: 'error', 
+          summary: 'Archive Job', detail: failureMessages.join('\n'), 
+          life: ToastTimeout.timeoutError};
+        toast.add(tMsg); addToastRecord(tMsg);
+      }
       refreshJobList();
     } else {
       useApiErrorResponsePreprocess(response).forEach(message => {


### PR DESCRIPTION
If a job in the Calibration or Evaluation runs list is running (or has running validation jobs), don't show the Delete and Archive options for that jobs.

Also don't show the Delete option for locked jobs.

When Deleting or Archiving a job, make sure the Toast message shown on screen matches the one in the server response. If success=false in the server response, the Toast message should display as an error (red instead of green).