### PR TITLE
Dwmartin ngwpc 8793 ngen forcing logging

### DIFF
--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -137,7 +137,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <!-- ngen and ngen-forcing rows at the top -->
+                  <!-- ngen and forcing rows at the top -->
                   <tr>
                     <td class="pr-4">ngen</td>
                     <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen' + level"
@@ -147,10 +147,10 @@
                     </td>
                   </tr>
                   <tr>
-                    <td class="pr-4">ngen-forcing</td>
-                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen-forcing' + level"
+                    <td class="pr-4">forcing</td>
+                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'forcing' + level"
                       class="px-2">
-                      <input type="radio" :name="'loglevel-ngen-forcing'" :value="level" v-model="ngenForcingLogLevel"
+                      <input type="radio" :name="'loglevel-forcing'" :value="level" v-model="forcingLogLevel"
                         :disabled="!calibrationJobNgenGlobalLogging" />
                     </td>
                   </tr>
@@ -273,7 +273,7 @@ const {
   gotoCalibrationRunId,
   calibrationJobNgenGlobalLogging,
   ngenLogLevel,
-  ngenForcingLogLevel,
+  forcingLogLevel,
   logLevels,
 } = storeToRefs(userDataStore);
 const { fetchUserCalibrationRunData } = userDataStore;
@@ -399,10 +399,10 @@ onMounted(async () => {
   } else {
     ngenLogLevel.value = 'info';
   }
-  if (userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing']) {
-    ngenForcingLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing'] as LogLevel;
+  if (userCalibrationRunData?.value?.logging_config?.modules['forcing']) {
+    forcingLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['forcing'] as LogLevel;
   } else {
-    ngenForcingLogLevel.value = 'info';
+    forcingLogLevel.value = 'info';
   }
   Object.keys(userCalibrationRunData?.value?.logging_config?.modules).forEach(server_key => {
     // Find matching key in log levels somehow

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -137,12 +137,20 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <!-- ngen row at the top -->
+                  <!-- ngen and ngen-forcing rows at the top -->
                   <tr>
                     <td class="pr-4">ngen</td>
-                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen-' + level"
+                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen' + level"
                       class="px-2">
                       <input type="radio" :name="'loglevel-ngen'" :value="level" v-model="ngenLogLevel"
+                        :disabled="!calibrationJobNgenGlobalLogging" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="pr-4">ngen-forcing</td>
+                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen-forcing' + level"
+                      class="px-2">
+                      <input type="radio" :name="'loglevel-ngen-forcing'" :value="level" v-model="logLevels['ngen-forcing']"
                         :disabled="!calibrationJobNgenGlobalLogging" />
                     </td>
                   </tr>
@@ -264,7 +272,9 @@ const {
   userCalibrationRunData,
   gotoCalibrationRunId,
   calibrationJobNgenGlobalLogging,
+  calibrationJobNgenForcingLogging,
   ngenLogLevel,
+  ngenForcingLogLevel,
   logLevels,
 } = storeToRefs(userDataStore);
 const { fetchUserCalibrationRunData } = userDataStore;

--- a/components/Calibration/RunStatus.vue
+++ b/components/Calibration/RunStatus.vue
@@ -150,7 +150,7 @@
                     <td class="pr-4">ngen-forcing</td>
                     <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen-forcing' + level"
                       class="px-2">
-                      <input type="radio" :name="'loglevel-ngen-forcing'" :value="level" v-model="logLevels['ngen-forcing']"
+                      <input type="radio" :name="'loglevel-ngen-forcing'" :value="level" v-model="ngenForcingLogLevel"
                         :disabled="!calibrationJobNgenGlobalLogging" />
                     </td>
                   </tr>
@@ -272,7 +272,6 @@ const {
   userCalibrationRunData,
   gotoCalibrationRunId,
   calibrationJobNgenGlobalLogging,
-  calibrationJobNgenForcingLogging,
   ngenLogLevel,
   ngenForcingLogLevel,
   logLevels,
@@ -395,6 +394,16 @@ onMounted(async () => {
   const getStatusResponse = await queryGetCalibrationStatus(userCalibrationRunData?.value?.calibration_run_id as number);
 
   // set log levels
+  if (userCalibrationRunData?.value?.logging_config?.modules['ngen']) {
+    ngenLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['ngen'] as LogLevel;
+  } else {
+    ngenLogLevel.value = 'info';
+  }
+  if (userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing']) {
+    ngenForcingLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing'] as LogLevel;
+  } else {
+    ngenForcingLogLevel.value = 'info';
+  }
   Object.keys(userCalibrationRunData?.value?.logging_config?.modules).forEach(server_key => {
     // Find matching key in log levels somehow
     Object.keys(logLevels.value).forEach(ui_key => {
@@ -403,9 +412,6 @@ onMounted(async () => {
       }
     });
   });
-  if (userCalibrationRunData?.value?.logging_config?.modules['ngen']) {
-    ngenLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['ngen'] as LogLevel;
-  }
   if (userCalibrationRunData?.value && getStatusResponse.status === 200) {
     userCalibrationRunData.value.status = getStatusResponse._data.status;
     userCalibrationRunData.value.failure_messages = getStatusResponse._data.failure_messages;

--- a/components/Forecast/RunStatusTab.vue
+++ b/components/Forecast/RunStatusTab.vue
@@ -124,6 +124,69 @@
             </div>
           </div>
         </div>
+
+        <!--LOGGING SECTION-->
+        <div v-if="!(forecastJobId && overallColdStartForecastStatus) || ['Saved','Ready'].includes(overallColdStartForecastStatus)" 
+          class="col-span-5 p-2 border-t border-[#d9d9d9] flex flex-col items-center" id="LoggingSection">
+          <div class="mb-4">
+            <div class="inline-flex flex-col items-center">
+              <p class="font-semibold mb-2">Global Logging</p>
+              <div class="flex gap-6">
+                <label v-for="[label, val] in [['Enabled', true], ['Disabled', false]]" :key="label as string"
+                  class="flex items-center gap-1">
+                  <input type="radio" :value="val" v-model="forecastJobNgenGlobalLogging" />
+                  <span>{{ label }}</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div class="mb-4">
+            <p class="font-semibold mb-2 text-center">Ngen and Module Log Levels</p>
+            <div :class="[
+              'overflow-x-auto',
+              { 'opacity-50 pointer-events-none': !forecastJobNgenGlobalLogging }
+            ]">
+              <table class="table-auto text-left border-collapse mx-auto" aria-label="Module Logging Levels">
+                <thead>
+                  <tr>
+                    <th class="pr-4">Module</th>
+                    <th v-for="level in ['Debug', 'Info', 'Warning', 'Severe', 'Fatal']" :key="level" class="px-2">
+                      {{ level }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <!-- ngen and ngen-forcing rows at the top -->
+                  <tr>
+                    <td class="pr-4">ngen</td>
+                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen' + level"
+                      class="px-2">
+                      <input type="radio" :name="'loglevel-ngen'" :value="level" v-model="ngenLogLevel"
+                        :disabled="!forecastJobNgenGlobalLogging" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="pr-4">ngen-forcing</td>
+                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen-forcing' + level"
+                      class="px-2">
+                      <input type="radio" :name="'loglevel-ngen-forcing'" :value="level" v-model="ngenForcingLogLevel"
+                        :disabled="!forecastJobNgenGlobalLogging" />
+                    </td>
+                  </tr>
+                  <!-- Per-module logLevels -->
+                  <tr v-for="(val, module) in logLevels" :key="module">
+                    <td class="pr-4">{{ module }}</td>
+                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="level" class="px-2">
+                      <input type="radio" :name="`loglevel-${module}`" :value="level" v-model="logLevels[module]"
+                        :disabled="!forecastJobNgenGlobalLogging" />
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -181,6 +244,7 @@ import { useToast } from 'primevue/usetoast';
 import type { ToastMessageOptions } from "primevue/toast";
 
 import { generalStore } from '~/stores/common/GeneralStore';
+import { useUserDataStore } from '@/stores/common/UserDataStore';
 import { useForecastStore } from '@/stores/forecast/ForecastStore';
 
 import { hilightTab } from '@/composables/TabHilight';
@@ -191,6 +255,8 @@ const { isLoading } = storeToRefs(generalStore());
 const { addToastRecord } = generalStore();
 
 const toast = useToast();
+
+const { userCalibrationRunData, ngenLogLevel, ngenForcingLogLevel, logLevels } = storeToRefs(useUserDataStore());
 
 const {
   forecastJobId,
@@ -207,7 +273,8 @@ const {
   forecastJobStatusIntervalId,
   resultsPathname,
   calibrationRunForForecast,
-  overallColdStartForecastStatus
+  overallColdStartForecastStatus,
+  forecastJobNgenGlobalLogging,
 } = storeToRefs(useForecastStore());
 
 const {
@@ -234,6 +301,27 @@ onMounted(async () => {
   clearInterval(elapsedTimeIntervalId.value);
   forecastJobStatusIntervalId.value = undefined;
   elapsedTimeIntervalId.value = undefined;
+
+  // set log levels
+  if (calibrationRunForForecast?.value?.logging_config?.modules['ngen']) {
+    ngenLogLevel.value = calibrationRunForForecast?.value?.logging_config?.modules['ngen'] as LogLevel;
+  } else {
+    ngenLogLevel.value = 'info';
+  }
+  if (userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing']) {
+    ngenForcingLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing'] as LogLevel;
+  } else {
+    ngenForcingLogLevel.value = 'info';
+  }
+  
+  Object.keys(userCalibrationRunData?.value?.logging_config?.modules).forEach(server_key => {
+    // Find matching key in log levels somehow
+    Object.keys(logLevels.value).forEach(ui_key => {
+      if (ui_key.toLowerCase() == server_key.toLowerCase()) {
+        logLevels.value[ui_key] = ref(userCalibrationRunData?.value?.logging_config?.modules[server_key] as LogLevel);
+      }
+    });
+  });
 
   // load Run/Status tab data
   await loadForecastRunStatusTabData();
@@ -295,7 +383,7 @@ const startForecastRun = async () => {
     calibrationRunForForecast?.value?.calibration_run_id as number, 
     forecastConfiguration?.value?.name as string,
     cycleDate.value,
-    coldStartDate.value
+    coldStartDate.value,
   );
 
   if (createAndRunForecastJobResponse.status >= 200 && createAndRunForecastJobResponse.status < 300) {

--- a/components/Forecast/RunStatusTab.vue
+++ b/components/Forecast/RunStatusTab.vue
@@ -157,7 +157,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <!-- ngen and ngen-forcing rows at the top -->
+                  <!-- ngen and forcing rows at the top -->
                   <tr>
                     <td class="pr-4">ngen</td>
                     <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen' + level"
@@ -167,10 +167,10 @@
                     </td>
                   </tr>
                   <tr>
-                    <td class="pr-4">ngen-forcing</td>
-                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'ngen-forcing' + level"
+                    <td class="pr-4">forcing</td>
+                    <td v-for="level in ['debug', 'info', 'warning', 'severe', 'fatal']" :key="'forcing' + level"
                       class="px-2">
-                      <input type="radio" :name="'loglevel-ngen-forcing'" :value="level" v-model="ngenForcingLogLevel"
+                      <input type="radio" :name="'loglevel-forcing'" :value="level" v-model="forcingLogLevel"
                         :disabled="!forecastJobNgenGlobalLogging" />
                     </td>
                   </tr>
@@ -256,7 +256,7 @@ const { addToastRecord } = generalStore();
 
 const toast = useToast();
 
-const { userCalibrationRunData, ngenLogLevel, ngenForcingLogLevel, logLevels } = storeToRefs(useUserDataStore());
+const { userCalibrationRunData, ngenLogLevel, forcingLogLevel, logLevels } = storeToRefs(useUserDataStore());
 
 const {
   forecastJobId,
@@ -308,10 +308,10 @@ onMounted(async () => {
   } else {
     ngenLogLevel.value = 'info';
   }
-  if (userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing']) {
-    ngenForcingLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['ngen-forcing'] as LogLevel;
+  if (userCalibrationRunData?.value?.logging_config?.modules['forcing']) {
+    forcingLogLevel.value = userCalibrationRunData?.value?.logging_config?.modules['forcing'] as LogLevel;
   } else {
-    ngenForcingLogLevel.value = 'info';
+    forcingLogLevel.value = 'info';
   }
   
   Object.keys(userCalibrationRunData?.value?.logging_config?.modules).forEach(server_key => {

--- a/composables/NgencerfModels.ts
+++ b/composables/NgencerfModels.ts
@@ -740,6 +740,12 @@ export type CalibrationRunForForecast = {
   configuration: string;
   cycle_date: string;
   cold_start_date: string;
+  logging_config: {
+    logging_enabled: boolean;
+    modules: {
+      [key: string]: string;
+    }
+  }
 };
 
 export interface ForecastJob {

--- a/stores/calibration/RunStatusStore.ts
+++ b/stores/calibration/RunStatusStore.ts
@@ -215,7 +215,6 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
    * https://vuejs.org/guide/essentials/reactivity-fundamentals.html#reactive
    */
   const runCalibrationJob = async (): Promise<any> => {
-    console.log('ngenForcingLogLevel:',ngenForcingLogLevel.value);
     const rawLogLevels = toRaw(logLevels.value);
 
     // transform module ref values to their actual values to be sent to the backend

--- a/stores/calibration/RunStatusStore.ts
+++ b/stores/calibration/RunStatusStore.ts
@@ -29,7 +29,7 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
     userCalibrationRunData,
     calibrationJobNgenGlobalLogging,
     ngenLogLevel,
-    ngenForcingLogLevel,
+    forcingLogLevel,
     logLevels,
   } = storeToRefs(useUserDataStore());
 
@@ -239,10 +239,10 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
         logging_config: {
           logging_enabled: calibrationJobNgenGlobalLogging.value,
           ...(serializedModules && {
-            // add ngenLogLevel and ngenForcingLogLevel to beginning of the object
+            // add ngenLogLevel and forcingLogLevel to beginning of the object
             modules: {
               'ngen': ngenLogLevel.value,
-              'ngen-forcing': ngenForcingLogLevel.value,
+              'forcing': forcingLogLevel.value,
               ...serializedModules
             }
           })

--- a/stores/calibration/RunStatusStore.ts
+++ b/stores/calibration/RunStatusStore.ts
@@ -28,7 +28,6 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
   const {
     userCalibrationRunData,
     calibrationJobNgenGlobalLogging,
-    calibrationJobNgenForcingLogging,
     ngenLogLevel,
     ngenForcingLogLevel,
     logLevels,
@@ -216,6 +215,7 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
    * https://vuejs.org/guide/essentials/reactivity-fundamentals.html#reactive
    */
   const runCalibrationJob = async (): Promise<any> => {
+    console.log('ngenForcingLogLevel:',ngenForcingLogLevel.value);
     const rawLogLevels = toRaw(logLevels.value);
 
     // transform module ref values to their actual values to be sent to the backend

--- a/stores/calibration/RunStatusStore.ts
+++ b/stores/calibration/RunStatusStore.ts
@@ -28,7 +28,9 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
   const {
     userCalibrationRunData,
     calibrationJobNgenGlobalLogging,
+    calibrationJobNgenForcingLogging,
     ngenLogLevel,
+    ngenForcingLogLevel,
     logLevels,
   } = storeToRefs(useUserDataStore());
 
@@ -238,9 +240,10 @@ export const useRunStatusStore = defineStore('RunStatusStore', () => {
         logging_config: {
           logging_enabled: calibrationJobNgenGlobalLogging.value,
           ...(serializedModules && {
-            // add ngenLogLevel to beginning of the object
+            // add ngenLogLevel and ngenForcingLogLevel to beginning of the object
             modules: {
-              ngen: ngenLogLevel.value,
+              'ngen': ngenLogLevel.value,
+              'ngen-forcing': ngenForcingLogLevel.value,
               ...serializedModules
             }
           })

--- a/stores/common/UserDataStore.ts
+++ b/stores/common/UserDataStore.ts
@@ -45,9 +45,8 @@ export const useUserDataStore = defineStore(
 
     const lastServerError = ref<ServerStatus>();
 
-    // sets value for global and ngen-forcing logging
+    // sets value for global logging
     const calibrationJobNgenGlobalLogging = ref<boolean>(true);
-    const calibrationJobNgenForcingLogging = ref<boolean>(true);
 
     // set ngen log level
     const ngenLogLevel = ref<LogLevel>("info");
@@ -385,7 +384,6 @@ export const useUserDataStore = defineStore(
     const clearUserCalibrationRunData = () => {
       userCalibrationRunData.value = undefined;
       calibrationJobNgenGlobalLogging.value = true;
-      calibrationJobNgenForcingLogging.value = true;
       ngenLogLevel.value = "info";
       ngenForcingLogLevel.value = "info";
 
@@ -414,7 +412,6 @@ export const useUserDataStore = defineStore(
       userCalibrationRunData,
       gotoCalibrationRunId,
       calibrationJobNgenGlobalLogging,
-      calibrationJobNgenForcingLogging,
       ngenLogLevel,
       ngenForcingLogLevel,
       logLevels,

--- a/stores/common/UserDataStore.ts
+++ b/stores/common/UserDataStore.ts
@@ -50,7 +50,7 @@ export const useUserDataStore = defineStore(
 
     // set ngen log level
     const ngenLogLevel = ref<LogLevel>("info");
-    const ngenForcingLogLevel = ref<LogLevel>("info");
+    const forcingLogLevel = ref<LogLevel>("info");
 
     // stores the log level for each module
     const logLevels: Record<string, Ref<LogLevel>> = reactive({});
@@ -385,7 +385,7 @@ export const useUserDataStore = defineStore(
       userCalibrationRunData.value = undefined;
       calibrationJobNgenGlobalLogging.value = true;
       ngenLogLevel.value = "info";
-      ngenForcingLogLevel.value = "info";
+      forcingLogLevel.value = "info";
 
       // clear all log levels
       for (const module in logLevels) {
@@ -413,7 +413,7 @@ export const useUserDataStore = defineStore(
       gotoCalibrationRunId,
       calibrationJobNgenGlobalLogging,
       ngenLogLevel,
-      ngenForcingLogLevel,
+      forcingLogLevel,
       logLevels,
       isUserLoggedIn,
       logUserIn,

--- a/stores/common/UserDataStore.ts
+++ b/stores/common/UserDataStore.ts
@@ -45,11 +45,13 @@ export const useUserDataStore = defineStore(
 
     const lastServerError = ref<ServerStatus>();
 
-    // sets value for global logging
+    // sets value for global and ngen-forcing logging
     const calibrationJobNgenGlobalLogging = ref<boolean>(true);
+    const calibrationJobNgenForcingLogging = ref<boolean>(true);
 
     // set ngen log level
     const ngenLogLevel = ref<LogLevel>("info");
+    const ngenForcingLogLevel = ref<LogLevel>("info");
 
     // stores the log level for each module
     const logLevels: Record<string, Ref<LogLevel>> = reactive({});
@@ -383,7 +385,9 @@ export const useUserDataStore = defineStore(
     const clearUserCalibrationRunData = () => {
       userCalibrationRunData.value = undefined;
       calibrationJobNgenGlobalLogging.value = true;
+      calibrationJobNgenForcingLogging.value = true;
       ngenLogLevel.value = "info";
+      ngenForcingLogLevel.value = "info";
 
       // clear all log levels
       for (const module in logLevels) {
@@ -410,7 +414,9 @@ export const useUserDataStore = defineStore(
       userCalibrationRunData,
       gotoCalibrationRunId,
       calibrationJobNgenGlobalLogging,
+      calibrationJobNgenForcingLogging,
       ngenLogLevel,
+      ngenForcingLogLevel,
       logLevels,
       isUserLoggedIn,
       logUserIn,

--- a/stores/forecast/ForecastStore.ts
+++ b/stores/forecast/ForecastStore.ts
@@ -14,7 +14,7 @@ import { formatElapsedTime, formatDateForRunOnString } from '@/utils/TimeHelpers
 
 export const useForecastStore = defineStore('ForecastStore', () => {
   const { ngencerfBaseUrl } = useBackendConfig();
-  const { userCalibrationRunData, ngenLogLevel, ngenForcingLogLevel, logLevels } = storeToRefs(useUserDataStore());
+  const { userCalibrationRunData, ngenLogLevel, forcingLogLevel, logLevels } = storeToRefs(useUserDataStore());
   const {
     getAccessToken,
     fetchUserCalibrationRunData,
@@ -296,10 +296,10 @@ export const useForecastStore = defineStore('ForecastStore', () => {
         logging_config: {
           logging_enabled: forecastJobNgenGlobalLogging.value,
           ...(serializedModules && {
-            // add ngenLogLevel and ngenForcingLogLevel to beginning of the object
+            // add ngenLogLevel and forcingLogLevel to beginning of the object
             modules: {
               'ngen': ngenLogLevel.value,
-              'ngen-forcing': ngenForcingLogLevel.value,
+              'forcing': forcingLogLevel.value,
               ...serializedModules
             }
           })

--- a/stores/forecast/ForecastStore.ts
+++ b/stores/forecast/ForecastStore.ts
@@ -282,12 +282,6 @@ export const useForecastStore = defineStore('ForecastStore', () => {
         }
         return acc;
       }, {} as Record<string, LogLevel>);
-    console.log('serializedModules:',serializedModules.value);
-    console.log('modules:',{
-      'ngen': ngenLogLevel.value,
-      'ngen-forcing': ngenForcingLogLevel.value,
-      ...serializedModules
-    });
     return makeProtectedApiCall<CalibrationStatus>(`${ngencerfBaseUrl}/calibration/create_and_run_forecast/`, {
       method: "POST",
       headers: {

--- a/stores/forecast/ForecastStore.ts
+++ b/stores/forecast/ForecastStore.ts
@@ -14,7 +14,7 @@ import { formatElapsedTime, formatDateForRunOnString } from '@/utils/TimeHelpers
 
 export const useForecastStore = defineStore('ForecastStore', () => {
   const { ngencerfBaseUrl } = useBackendConfig();
-  const { userCalibrationRunData } = storeToRefs(useUserDataStore());
+  const { userCalibrationRunData, ngenLogLevel, ngenForcingLogLevel, logLevels } = storeToRefs(useUserDataStore());
   const {
     getAccessToken,
     fetchUserCalibrationRunData,
@@ -46,6 +46,8 @@ export const useForecastStore = defineStore('ForecastStore', () => {
   const forecastRuns = ref<ForecastJob[]>([]);
   const filteredForecastRuns = ref<ForecastJob[]>([]);
   const selectedForecastJob = ref<ForecastJob>();
+
+  const forecastJobNgenGlobalLogging = ref<boolean>(true);
 
   const isForecastLoading = ref<boolean>(false);
 
@@ -270,6 +272,22 @@ export const useForecastStore = defineStore('ForecastStore', () => {
     cycleDate: DateTime,
     coldStartDate: DateTime | null
   ): Promise<any> => {
+    const rawLogLevels = toRaw(logLevels.value);
+
+    // transform module ref values to their actual values to be sent to the backend
+    const serializedModules: Record<string, LogLevel> | undefined =
+      Object.entries(rawLogLevels).reduce((acc, [key, val]) => {
+        if (val && typeof val === 'object' && 'value' in val) {
+          acc[key] = val.value;
+        }
+        return acc;
+      }, {} as Record<string, LogLevel>);
+    console.log('serializedModules:',serializedModules.value);
+    console.log('modules:',{
+      'ngen': ngenLogLevel.value,
+      'ngen-forcing': ngenForcingLogLevel.value,
+      ...serializedModules
+    });
     return makeProtectedApiCall<CalibrationStatus>(`${ngencerfBaseUrl}/calibration/create_and_run_forecast/`, {
       method: "POST",
       headers: {
@@ -280,7 +298,18 @@ export const useForecastStore = defineStore('ForecastStore', () => {
         calibration_run_id: calibrationRunId, 
         configuration_name: forecastConfigurationName,
         cycle_date: cycleDate ? formatISOStringOrDateToYYYYMMDDHHMM(cycleDate) : null,
-        cold_start_date: coldStartDate ? formatISOStringOrDateToYYYYMMDDHHMM(coldStartDate) : null
+        cold_start_date: coldStartDate ? formatISOStringOrDateToYYYYMMDDHHMM(coldStartDate) : null,
+        logging_config: {
+          logging_enabled: forecastJobNgenGlobalLogging.value,
+          ...(serializedModules && {
+            // add ngenLogLevel and ngenForcingLogLevel to beginning of the object
+            modules: {
+              'ngen': ngenLogLevel.value,
+              'ngen-forcing': ngenForcingLogLevel.value,
+              ...serializedModules
+            }
+          })
+        },
       })
     });
   };
@@ -475,6 +504,8 @@ export const useForecastStore = defineStore('ForecastStore', () => {
       clearInterval(forecastJobStatusIntervalId.value);
       forecastJobStatusIntervalId.value = undefined;
     }
+
+    forecastJobNgenGlobalLogging.value = true;
   };
 
   return {
@@ -504,6 +535,7 @@ export const useForecastStore = defineStore('ForecastStore', () => {
     selectedForecastJob,
     isForecastLoading,
     overallColdStartForecastStatus,
+    forecastJobNgenGlobalLogging,
     getForecastJobs,
     loadSetupForecastTabData,
     loadForecastRunStatusTabData,


### PR DESCRIPTION
Allow ngen-forcing log level to be chosen when running a calibration job.

Allow all logging levels (ngen, ngen-forcing, and all modules in the formulation) to be set when running a forecast job. Log levels should default to the same as the calibration job, but they can be changed at this point.

NOTE: This currently doesn't work for LSTM jobs - seems to be a problem with the internal forecast manager code and not specific to the log levels.