### PR TITLE
Handle server response better when updating password/name

### DIFF
--- a/components/Common/AppHeader.vue
+++ b/components/Common/AppHeader.vue
@@ -204,11 +204,10 @@ const { getMenuIndex, setMenuIndex, getCalibrationTabIndex, getEvaluationTabInde
 
 const { isUserLoggedIn, getUserInitials, setIsTokenExpired, getIsTokenExpired } = useUserDataStore();
 
-const { lastServerError } = storeToRefs(useUserDataStore());
+const { userInitials, lastServerError } = storeToRefs(useUserDataStore());
 
 const location = useRoute();
 
-const userInitials = ref<string>('');
 const userLoggedIn = ref<boolean>();
 
 import pdfUrl from '@/assets/styles/pdfs/NGWPC_NgenCERF_Users_Guide.pdf';

--- a/components/Common/UserAccount.vue
+++ b/components/Common/UserAccount.vue
@@ -7,7 +7,7 @@
       <div class="col-span-2">
         <div class="ttl">Your Account</div>
         <div class="name">
-          {{ fullName }}
+          {{ firstName }} {{ lastName }}
           <span class="pt-1 inline-block ml-3" style="font-size:0.7em;">( {{ userName }} )</span>
         </div>
       </div>
@@ -121,12 +121,15 @@ import { useBackendConfig } from "@/composables/UseBackendConfig";
 
 const { addToastRecord } = generalStore();
 
+const { firstName, lastName, userInitials } = storeToRefs(useUserDataStore());
+
 const {
   getAccessToken,
   getUserName,
   getUserFullName,
   getUserFirstName,
   getUserLastName,
+  getUserInitials,
   setFirstName,
   setLastName
 } = useUserDataStore();
@@ -186,6 +189,7 @@ const changePassword = async () => {
   passwordChangeData.new_password = newpass.value.trim();
   passwordChangeData.re_new_password = confirmNewpass.value.trim();
 
+  toast.removeAllGroups();
   if (passwordChangeData.current_password !== "" && passwordChangeData.new_password !== "" && passwordChangeData.re_new_password !== ""
     && (passwordChangeData.new_password === passwordChangeData.re_new_password)) {
     const { data, error } = await useFetch<any>(`${ngencerfBaseUrl}/auth/users/set_password/`, {
@@ -196,15 +200,19 @@ const changePassword = async () => {
       },
       body: passwordChangeData
     });
-    // error.value.statuscode
-    if (error.value) {
-      let e = error.value?.data?.detail;
+    if (error?.value) {
+      let e = error.value?.data;
       if (!e) {
-        e = "Cannot reach server. Error code: " + error.value.statusCode;
+        const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "Cannot reach server. Error code: " + error.value.statusCode, life: ToastTimeout.timeoutError };
+        toast.add(tMsg); addToastRecord(tMsg);
+      } else {
+        for (const key of Object.keys(e)) {
+          for (const message of e[key]) {
+            const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: message, life: ToastTimeout.timeoutError };
+            toast.add(tMsg); addToastRecord(tMsg);
+          }
+        }
       }
-      const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Error', detail: e, life: ToastTimeout.timeoutError };
-      toast.add(tMsg); addToastRecord(tMsg);
-      console.error("Error during user creation:", error.value?.message, error.value?.data);
       return;
     }
     // Clear out the inputs and report success
@@ -213,8 +221,14 @@ const changePassword = async () => {
     confirmNewpass.value = "";
     const tMsg: ToastMessageOptions = { severity: 'success', summary: 'Password Change Successful', detail: "You have successfully changed your password", life: ToastTimeout.timeoutSuccess };
     toast.add(tMsg); addToastRecord(tMsg);
+  } else if (passwordChangeData.current_password === "" || passwordChangeData.new_password === "" || passwordChangeData.re_new_password === "") {
+    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "All fields must be filled out.", life: ToastTimeout.timeoutError };
+    toast.add(tMsg); addToastRecord(tMsg);
+  } else if (passwordChangeData.new_password !== passwordChangeData.re_new_password) {
+    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "New password fields do not match.", life: ToastTimeout.timeoutError };
+    toast.add(tMsg); addToastRecord(tMsg);
   } else {
-    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "Password was not changed", life: ToastTimeout.timeoutError };
+    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "Your password was not changed.", life: ToastTimeout.timeoutError };
     toast.add(tMsg); addToastRecord(tMsg);
   }
 }
@@ -227,6 +241,7 @@ const updateName = async () => {
   updateNameData.first_name = newFirstName.value.trim();
   updateNameData.last_name = newLastName.value.trim();
 
+  toast.removeAllGroups();
   if (updateNameData.first_name !== "" && updateNameData.last_name !== "") {
     const { data, error } = await useFetch<any>(`${ngencerfBaseUrl}/auth/users/me/`, {
       method: 'PATCH',
@@ -236,21 +251,29 @@ const updateName = async () => {
       },
       body: updateNameData
     });
-    // error.value.statuscode
-    if (error.value) {
-      let e = error.value?.data?.detail;
+    if (error?.value) {
+      let e = error.value?.data;
       if (!e) {
-        e = "Cannot reach server. Error code: " + error.value.statusCode;
+        const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: "Cannot reach server. Error code: " + error.value.statusCode, life: ToastTimeout.timeoutError };
+        toast.add(tMsg); addToastRecord(tMsg);
+      } else {
+        for (const key of Object.keys(e)) {
+          for (const message of e[key]) {
+            const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: message, life: ToastTimeout.timeoutError };
+            toast.add(tMsg); addToastRecord(tMsg);
+          }
+        }
       }
-      const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Error', detail: e, life: ToastTimeout.timeoutError };
-      toast.add(tMsg); addToastRecord(tMsg);
-      console.error("Error during user update:", error.value?.message, error.value?.data);
       return;
     }
     // Clear out the inputs and report success
     setFirstName(updateNameData.first_name);
     setLastName(updateNameData.last_name);
+    userInitials.value = getUserInitials();
     const tMsg: ToastMessageOptions = { severity: 'success', summary: 'Name Change Successful', detail: "You have successfully changed your name", life: ToastTimeout.timeoutSuccess };
+    toast.add(tMsg); addToastRecord(tMsg);
+  } else if (updateNameData.first_name === "" || updateNameData.last_name=== "") {
+    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: "First and last names must be filled out.", life: ToastTimeout.timeoutError };
     toast.add(tMsg); addToastRecord(tMsg);
   } else {
     const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: "Name was not changed", life: ToastTimeout.timeoutError };

--- a/components/Common/UserAccount.vue
+++ b/components/Common/UserAccount.vue
@@ -190,8 +190,12 @@ const changePassword = async () => {
   passwordChangeData.re_new_password = confirmNewpass.value.trim();
 
   toast.removeAllGroups();
-  if (passwordChangeData.current_password !== "" && passwordChangeData.new_password !== "" && passwordChangeData.re_new_password !== ""
-    && (passwordChangeData.new_password === passwordChangeData.re_new_password)) {
+  let failureMessages: string[] = [];
+  if (passwordChangeData.current_password === "" || passwordChangeData.new_password === "" || passwordChangeData.re_new_password === "") {
+    failureMessages.push("All fields must be filled out.");
+  } else if (passwordChangeData.new_password !== passwordChangeData.re_new_password) {
+    failureMessages.push("New password fields do not match.");
+  } else {
     const { data, error } = await useFetch<any>(`${ngencerfBaseUrl}/auth/users/set_password/`, {
       method: 'POST',
       headers: {
@@ -203,32 +207,27 @@ const changePassword = async () => {
     if (error?.value) {
       let e = error.value?.data;
       if (!e) {
-        const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "Cannot reach server. Error code: " + error.value.statusCode, life: ToastTimeout.timeoutError };
-        toast.add(tMsg); addToastRecord(tMsg);
+        failureMessages.push("Cannot reach server. Error code: " + error.value.statusCode);
       } else {
         for (const key of Object.keys(e)) {
           for (const message of e[key]) {
-            const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: message, life: ToastTimeout.timeoutError };
-            toast.add(tMsg); addToastRecord(tMsg);
+            failureMessages.push(message);
           }
         }
       }
-      return;
+    } else {
+      // Clear out the inputs and report success
+      oldpass.value = "";
+      newpass.value = "";
+      confirmNewpass.value = "";
     }
-    // Clear out the inputs and report success
-    oldpass.value = "";
-    newpass.value = "";
-    confirmNewpass.value = "";
-    const tMsg: ToastMessageOptions = { severity: 'success', summary: 'Password Change Successful', detail: "You have successfully changed your password", life: ToastTimeout.timeoutSuccess };
-    toast.add(tMsg); addToastRecord(tMsg);
-  } else if (passwordChangeData.current_password === "" || passwordChangeData.new_password === "" || passwordChangeData.re_new_password === "") {
-    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "All fields must be filled out.", life: ToastTimeout.timeoutError };
-    toast.add(tMsg); addToastRecord(tMsg);
-  } else if (passwordChangeData.new_password !== passwordChangeData.re_new_password) {
-    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "New password fields do not match.", life: ToastTimeout.timeoutError };
+  }
+  if (failureMessages.length > 0) {
+    failureMessages.push("Password not updated.");
+    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: failureMessages.join('\n'), life: ToastTimeout.timeoutSuccess };
     toast.add(tMsg); addToastRecord(tMsg);
   } else {
-    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Password Change Error', detail: "Your password was not changed.", life: ToastTimeout.timeoutError };
+    const tMsg: ToastMessageOptions = { severity: 'success', summary: 'Password Change Successful', detail: "You have successfully changed your password", life: ToastTimeout.timeoutSuccess };
     toast.add(tMsg); addToastRecord(tMsg);
   }
 }
@@ -242,7 +241,10 @@ const updateName = async () => {
   updateNameData.last_name = newLastName.value.trim();
 
   toast.removeAllGroups();
-  if (updateNameData.first_name !== "" && updateNameData.last_name !== "") {
+  let failureMessages: string[] = [];
+  if (updateNameData.first_name === "" || updateNameData.last_name=== "") {
+    failureMessages.push("First and last names must be filled out.")
+  } else {
     const { data, error } = await useFetch<any>(`${ngencerfBaseUrl}/auth/users/me/`, {
       method: 'PATCH',
       headers: {
@@ -254,29 +256,27 @@ const updateName = async () => {
     if (error?.value) {
       let e = error.value?.data;
       if (!e) {
-        const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: "Cannot reach server. Error code: " + error.value.statusCode, life: ToastTimeout.timeoutError };
-        toast.add(tMsg); addToastRecord(tMsg);
+        failureMessages.push("Cannot reach server. Error code: " + error.value.statusCode);
       } else {
         for (const key of Object.keys(e)) {
           for (const message of e[key]) {
-            const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: message, life: ToastTimeout.timeoutError };
-            toast.add(tMsg); addToastRecord(tMsg);
+            failureMessages.push(message);
           }
         }
       }
-      return;
+    } else {
+      // Clear out the inputs and report success
+      setFirstName(updateNameData.first_name);
+      setLastName(updateNameData.last_name);
+      userInitials.value = getUserInitials();
     }
-    // Clear out the inputs and report success
-    setFirstName(updateNameData.first_name);
-    setLastName(updateNameData.last_name);
-    userInitials.value = getUserInitials();
-    const tMsg: ToastMessageOptions = { severity: 'success', summary: 'Name Change Successful', detail: "You have successfully changed your name", life: ToastTimeout.timeoutSuccess };
-    toast.add(tMsg); addToastRecord(tMsg);
-  } else if (updateNameData.first_name === "" || updateNameData.last_name=== "") {
-    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: "First and last names must be filled out.", life: ToastTimeout.timeoutError };
+  }
+  if (failureMessages.length > 0) {
+    failureMessages.push("Name not updated.");
+    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: failureMessages.join('\n'), life: ToastTimeout.timeoutSuccess };
     toast.add(tMsg); addToastRecord(tMsg);
   } else {
-    const tMsg: ToastMessageOptions = { severity: 'error', summary: 'Name Change Error', detail: "Name was not changed", life: ToastTimeout.timeoutError };
+    const tMsg: ToastMessageOptions = { severity: 'success', summary: 'Name Change Successful', detail: "You have successfully changed your name", life: ToastTimeout.timeoutSuccess };
     toast.add(tMsg); addToastRecord(tMsg);
   }
 }

--- a/stores/common/UserDataStore.ts
+++ b/stores/common/UserDataStore.ts
@@ -25,6 +25,7 @@ export const useUserDataStore = defineStore(
     const userName = ref("");
     const firstName = ref("");
     const lastName = ref("");
+    const userInitials = ref<string>('');
     const accessToken = ref<string | null>(null);
     const refreshToken = ref<string | null>(null);
 
@@ -133,18 +134,22 @@ export const useUserDataStore = defineStore(
      * @returns {string} name of user
      */
     function getUserInitials(): string {
-      let n = userName.value;
-      if (n) {
-        let atSignPos = n.indexOf("@");
-        if (atSignPos !== -1) {
-          let name = n.substring(0, atSignPos);
-          let dotPos = name.lastIndexOf(".");
-          if (dotPos !== -1) {
-            return (name[0] + name.substring(dotPos + 1)[0]).toUpperCase();
+      if (firstName.value && lastName.value) {
+        return firstName.value.toUpperCase()[0] + lastName.value.toUpperCase()[0];
+      } else {
+        let n = userName.value;
+        if (n) {
+          let atSignPos = n.indexOf("@");
+          if (atSignPos !== -1) {
+            let name = n.substring(0, atSignPos);
+            let dotPos = name.lastIndexOf(".");
+            if (dotPos !== -1) {
+              return (name[0] + name.substring(dotPos + 1)[0]).toUpperCase();
+            }
+            return userName.value.toUpperCase()[0];
+          } else {
+            return userName.value.toUpperCase()[0];
           }
-          return userName.value.toUpperCase()[0];
-        } else {
-          return userName.value.toUpperCase()[0];
         }
       }
       return "";
@@ -394,6 +399,7 @@ export const useUserDataStore = defineStore(
       userName,
       firstName,
       lastName,
+      userInitials,
       accessToken,
       refreshToken,
       modulesFilterList,


### PR DESCRIPTION
On user Account Screen:
- Updating password or First/Last Name should show detailed errors as Toast messages when there is a problem
- Updating password or First/Last Name should show success message when OK
- Updating First/Last Name should also live update the name seen at the top of the Account Screen and the initials in the blue circle at the top left