### PR TITLE
Fixes to make UI/server consistent for Verification workflow

### DIFF
--- a/components/Verification/VerificationRunsTab.vue
+++ b/components/Verification/VerificationRunsTab.vue
@@ -192,9 +192,6 @@ const onRowContextMenu = (event: any) => {
   const vrRowData = event.data as VerificationJob;
   if (selectedVerificationJob && selectedVerificationJob.value?.verification_run_id === vrRowData.verification_run_id) {
     vrContextMenu.value.show(event.originalEvent);
-    if (['Saved','Ready'].includes(vrRowData.status)) {
-      cmVerificationJob.value.push({ label: 'Show Setup', icon: 'pi pi-bars', command: () => navigateToSetupVerification() });
-    }
     cmVerificationJob.value.push({ label: 'View Status', icon: 'pi pi-gauge', command: () => navigateToVerificationJobStatus() });
     if (vrRowData.status === 'Done') {
       cmVerificationJob.value.push({ label: 'View Results', icon: 'pi pi-chart-line', command: () => navigateToVerificationResults() });

--- a/stores/verification/VerificationStore.ts
+++ b/stores/verification/VerificationStore.ts
@@ -218,6 +218,7 @@ export const useVerificationStore = defineStore('VerificationStore', () => {
    * @return {any}
    */
   const getVerificationStatus = async (): Promise<any> => {
+    console.log('userVerificationJobData:',userVerificationJobData.value);
     return makeProtectedApiCall<CalibrationStatus>(`${ngencerfBaseUrl}/calibration/get_verification_status/`, {
       method: "POST",
       headers: {


### PR DESCRIPTION
UI should now use the proper calculation for elapsed time, defined as either the job end time (if done) or the current time (if still running) minus the moment the job was sent to the server due to the Run button was clicked.

Check this for all job types: Calibration, Evaluation, Forecast, Verification.

Verification workflow has also been updated to fix inconsistencies with how the server and UI were handling job ownership and referencing the job IDs.